### PR TITLE
convert to single page HTML with table of contents

### DIFF
--- a/accessibility.adoc
+++ b/accessibility.adoc
@@ -1,5 +1,4 @@
-= Accessibility
-include::_settings.adoc[]
+== Accessibility
 
 In a view, editor, or other control, every features should be accessible
 using a mouse or the keyboard.
@@ -12,7 +11,7 @@ TIP: [guideline18.1]*Guideline 18.1* +
 All of the features provided by a tool should be accessible using a
 mouse or the keyboard.
 
-== Standard Accelerators
+=== Standard Accelerators
 
 The Eclipse platform has defined a large number of shortcut keys.
 Plug-in developers should make sure that the existing shortcut keys do

--- a/best_practices.adoc
+++ b/best_practices.adoc
@@ -1,10 +1,9 @@
-= Best Practices
-include::_settings.adoc[]
+== Best Practices
 
 In this section, we provide examples of best practices for designing and
 implementing some common user interactions within the Eclipse platform.
 
-== Syntax and Compilation Error Handling
+=== Syntax and Compilation Error Handling
 
 When designing editors that provide syntax or compilation checking
 support, follow the Java tooling design in the Eclipse platform.
@@ -31,7 +30,7 @@ warnings.
 
 image::images/Bp2.gif[bp2,title="bp2"]
 
-== Coding Assistance
+=== Coding Assistance
 
 In addition to supporting the standard content assist in an editor,
 editors should exploit the use of Quick Fixes and Quick Assist. Use the
@@ -67,7 +66,7 @@ modified URL.
 
 image::images/Bp6.gif[bp6,title="bp6"]
 
-== Context Menu
+=== Context Menu
 
 Here is one suggested process to reason why a menu item should be added
 or removed from the context menu. The objective is to reduce the number
@@ -82,7 +81,7 @@ replace submenus. Fifth, remove menu items that are frequently used,
 selection sensitive, but have a dominant keyboard shortcut key defined,
 except for clipboard and save operations.
 
-== Labels, Fonts and Layout for Flat Look Design
+=== Labels, Fonts and Layout for Flat Look Design
 
 For Flat Look design, when using buttons with ellipses (except for the
 "More..." button), it should pop up a secondary window which can be a
@@ -108,7 +107,7 @@ enabled state, use RBG value (128, 128, 128) for disabled state.
 
 image::images/Flatlook9.gif[flatlook9,title="flatlook9"]
 
-== Decorators
+=== Decorators
 
 Enabling and disabling the decorators are extremely useful when the
 decorations performed by two or more decorators conflict with each
@@ -120,7 +119,7 @@ decoration performed by two different decorators on the same resource
 conflict, users should appropriately enable / disable different
 decorators to get the required decoration.
 
-=== Implementation Tip
+==== Implementation Tip
 It is very important to design custom decorators that don't conflict
 with basic decorations provided by different Eclipse views. For example,
 the package explorer view decorates Java files with problem markers (a

--- a/component_dev.adoc
+++ b/component_dev.adoc
@@ -1,7 +1,6 @@
-= Component Development
-include::_settings.adoc[]
+== Component Development
 
-== Commands
+=== Commands
 A command, which is invoked by a user to carry out some specific
 functions, may appear as an item in a menu, or an item in a toolbar. In
 reflection of this, it has attributes for the menu or tool item label,
@@ -21,7 +20,7 @@ In this section we'll look at general command guidelines. For
 information on window, view, or editor specific guidelines, see
 xref:#_windows[Windows], xref:#_views[Views], and xref:#_editors[Editors].
 
-=== Appearance
+==== Appearance
 
 Each command must have a label, tool tip, and image. If the command
 appears in a toolbar, the command image will be displayed on all
@@ -78,7 +77,7 @@ TIP: [guideline3.3]*Guideline 3.3* +
 Adopt the labeling terminology of the workbench for New, Delete and Add
 commands.
 
-=== Enablement
+==== Enablement
 
 An command should be enabled only if it can be completed successfully.
 If this is not the case, the command should be disabled.
@@ -98,11 +97,11 @@ quick, enable the command optimistically and display an appropriate
 message if the command is invoked, but cannot be completed.
 
 
-== Dialogs
+=== Dialogs
 A dialog is used for modal interaction with the user. It can be used to
 solicit information, or provide feedback.
 
-=== Initialization
+==== Initialization
 
 When a dialog first opens, the initial focus should be given to the
 first control where information is required from the user. This control
@@ -116,7 +115,7 @@ When a dialog opens, set the initial focus to the first input control in
 the container. If there are no input controls, the initial focus should
 be assigned to the default button.
 
-=== Multiple Item Selection
+==== Multiple Item Selection
 Slush Bucket widgets (also known as the Twin Box design) should flow
 from the left to the right with the source objects on the left and
 selected files on the right.
@@ -139,7 +138,7 @@ Slush Bucket widget (or Twin Box) should flow from left to right with
 the source objects on the left hand side. It should have the control
 buttons in this order: 'Add ->', '', '
 
-== Wizards
+=== Wizards
 
 In Eclipse, a wizard is commonly used for the creation of new resources,
 resource import, or resource export. It can also be used for the
@@ -151,7 +150,7 @@ TIP: [guideline5.1]*Guideline 5.1* +
 Use a wizard for any task consisting of many steps, which must be
 completed in a specific order.
 
-=== Appearance
+==== Appearance
 
 At the top of each wizard is a header, containing a banner graphic and a
 text area. The banner graphic contains an image representing the wizard
@@ -173,7 +172,7 @@ Each wizard must contain a header with a banner graphic and a text area
 for user feedback. It must also contain Back, Next, Finish, and Cancel
 buttons in the footer.
 
-=== Initialization
+==== Initialization
 
 When a wizard first opens, the focus should be placed in the first field
 requiring information (see Guidelines 3.1). The header should be used to
@@ -206,7 +205,7 @@ image::images/wizardFieldPopulation.png[wizardFieldPopulation]
 TIP: [guideline5.4]**Guideline 5.4** +
 Seed the fields within the wizard using the current workbench state.
 
-=== Validation of Data
+==== Validation of Data
 Information validation within a wizard should be done in tab order. If
 the first required field is empty, an informative prompt should be shown
 in the text area, directing the user to fill in the field. If the first
@@ -243,7 +242,7 @@ image::images/wizardMsgs.png[wizardMsgs]
 TIP: [guideline5.7]*Guideline 5.7* +
 Remove all programming message ID's from wizard text.
 
-=== Browse Buttons
+==== Browse Buttons
 An edit field and "Browse..." button combination should be used whenever
 an existing object is referenced within a wizard. The edit field is used
 for direct input of the existing object, and the Browse button is used
@@ -270,7 +269,7 @@ snapshot.
 
 image::images/folderSelection.png[folderSelection]
 
-=== Wizard Completion
+==== Wizard Completion
 The New Resource and Import Wizards commonly create new files, folders,
 and projects within the workbench. If a single file is created, the
 wizard should open the file in an editor in the active page. If more
@@ -330,7 +329,7 @@ image::images/goodParentCreation.png[goodParentCreation]
 TIP: [guideline5.12]*Guideline 5.12* +
 Create folder objects in a wizard if reasonable defaults can be defined.
 
-=== Terminology
+==== Terminology
 
 Within a creation wizard, if the item being created must be a Project
 (not a folder below a project), the term "Project" should be used. If it
@@ -344,7 +343,7 @@ Use the term "Project name" for the input field label when the item must
 be a Project; otherwise, use the term "Folder name". Do not qualify the
 term.
 
-== Editors
+=== Editors
 
 An editor is a visual component within a workbench page. It is used to
 interact with the primary content, which may be a document or data
@@ -383,7 +382,7 @@ TIP: [guideline6.4]**Guideline 6.4** +
 It must be possible to open a separate instance of an editor for each
 different input.
 
-=== Appearance
+==== Appearance
 
 The editor should be labeled with the name of the resource being edited;
 not with the name of the editor.
@@ -404,7 +403,7 @@ TIP: [guideline6.6]*Guideline 6.6* +
 In multipage editors, use a tab control for page activation.Tab labels
 should be kept to one word, and two words at most.
 
-=== Menus
+==== Menus
 
 An editor may contribute items directly to the window menu bar. All of
 the commands available in the editor should be displayed in the window
@@ -467,7 +466,7 @@ If an editor has support for Cut, Copy, Paste, or any of the global
 commands, these commands must be executable from the same commands in
 the window menu bar and toolbar.
 
-=== Toolbars
+==== Toolbars
 
 An editor may contribute commands directly to the window toolbar. The
 toolbar is used to expose the _most commonly used_ commands in an
@@ -485,7 +484,7 @@ with editors of the same type. This reduces the flash which occurs when
 you switch between editors, reduces the number of images and commands in
 the product, and creates a better feel of integration.
 
-=== Context Menus
+==== Context Menus
 
 A context menu should be used for context sensitive interaction with the
 objects in an editor. If an object is selected in an editor, and the
@@ -554,7 +553,7 @@ Register all context menus in the editor with the platform.
 TIP: [guideline6.15]*Guideline 6.15* +
 Implement an Command Filter for each object type in the editor.
 
-=== Resource Deletion
+==== Resource Deletion
 
 When a resource is deleted from one of the navigators (e.g., Navigator
 view, J2EE view, Data view, or DBA Explorer view in IBM's WebSphere
@@ -580,7 +579,7 @@ If the input to an editor is deleted, and the editor contains changes,
 the editor should give the user a chance to save their changes to
 another location, and then close.
 
-=== Unsaved Changes
+==== Unsaved Changes
 
 If the editor contains changes to the resource since the resource was
 last saved (i.e., it is "dirty"), an asterisk should be used to prefix
@@ -592,7 +591,7 @@ TIP: [guideline6.18]*Guideline 6.18* +
 If the resource is dirty, prefix the resource name presented in the
 editor tab with an asterisk.
 
-=== Read-Only Files
+==== Read-Only Files
 
 With a name like "editor", it's not surprising that the issue of
 read-only files may cause confusion. If it's read-only, how can you edit
@@ -614,7 +613,7 @@ TIP: [guideline6.19]*Guideline 6.19* +
 Treat read-only editor input as you would any other input. Enable the
 Save As if possible. Display "Read-only" in the status bar area.
 
-=== Integration with Other Views
+==== Integration with Other Views
 
 In Eclipse, there is a special relationship between each editor and the
 Outline view. When an editor is opened, the Outline view will connect to
@@ -693,7 +692,7 @@ defined in the Task.
 TIP: [guideline6.24]*Guideline 6.24* +
 If appropriate, implement the "Add Bookmark" feature in your editor.
 
-=== Line Numbers
+==== Line Numbers
 
 Editors with source lines of text should have line numbers, and
 optionally column numbers. Editors should also support Navigate -> Goto
@@ -707,7 +706,7 @@ Editors with source lines of text should show the current line and
 optionally column numbers the status line. It's optional for the editor
 to show line numbers for each line in the editor itself.
 
-=== Table Cell Editors
+==== Table Cell Editors
 
 If the editor contains tables with editable cells, a single-click over a
 cell should select the current item and put the cell into edit mode. In
@@ -750,7 +749,7 @@ clicks off the cell or hits the "Enter" key. Selection should be
 cancelled when user hits the "Esc" key.First letter navigation should be
 supported as a cursoring mechanism within a cell.
 
-=== Error Notification
+==== Error Notification
 
 If you are doing keystroke by keystroke validation in an editor, use red
 squiggles to underline the invalid content. When users move the mouse
@@ -768,7 +767,7 @@ TIP: [guideline6.29]*Guideline 6.29* +
 Use the Problems view to show errors found when the Save command is
 invoked.
 
-=== Interaction With External Editors
+==== Interaction With External Editors
 
 While a resource is opened within the workbench, if modifications are
 made to it outside of the workbench, we recommend the following approach
@@ -784,7 +783,7 @@ should be prompted to either override the changes made outside of the
 workbench, or back out of the Save operation when the Save command is
 invoked in the editor.
 
-== Views
+=== Views
 
 A view is a visual component within a workbench page. It is used in a
 support role for the primary task. You use them to navigate a hierarchy
@@ -844,7 +843,7 @@ Window > Show View > Other... dialog.
 TIP: [guideline7.5]*Guideline 7.5* +
 A view can be opened from the Window > Show View menu.
 
-=== Appearance
+==== Appearance
 
 A view consists of a title area, a toolbar, a pulldown menu, and an
 embedded control.
@@ -872,7 +871,7 @@ TIP: [guideline7.7]*Guideline 7.7* +
 If a view contains more than one control, it may be advisable to split
 it up into two or more views.
 
-=== Initialization
+==== Initialization
 
 When a view is opened, the input of the view should be derived from the
 state of the perspective. The view may consult the window input or
@@ -897,7 +896,7 @@ TIP: [guideline7.9]*Guideline 7.9**
 If a view displays a resource tree, consider using the window input as
 the root of visible information in the view.
 
-=== Menus
+==== Menus
 
 Use the view pulldown menu for presentation commands, not
 selection-oriented commands. These are commands which affect the
@@ -952,7 +951,7 @@ TIP: [guideline7.11]*Guideline 7.11* +
 Use the standard order of commands for view pulldown menus.
 
 
-=== Toolbars
+==== Toolbars
 The toolbar is used to expose the most commonly used commands in a view.
 Any command which appears in the toolbar must also appear in the menu
 (either the context menu or the view menu), but there is no need to
@@ -964,7 +963,7 @@ a toolbar must also appear in a menu, either the context menu or the
 view menu.
 
 
-=== Context Menus
+==== Context Menus
 A context menu should be used for context sensitive interaction with the
 objects in a view. If an object is selected in a view, and the context
 menu is opened, the context menu should contain only actions which are
@@ -1053,7 +1052,7 @@ Register all context menus in the view with the platform.
 TIP: [guideline7.18]*Guideline 7.18* +
 Implement an Command Filter for each object type in the view.
 
-=== Integration with the Window Menu Bar and Toolbar
+==== Integration with the Window Menu Bar and Toolbar
 
 
 The window menu bar contains a number of global commands, such as Cut,
@@ -1091,7 +1090,7 @@ menu. In addition, the primary perspective(s) for such views (e.g., the Java
 and Java Browsing perspectives) should already have these action sets
 associated with the perspective, to improve UI stability.
 
-=== Persistence
+==== Persistence
 One of the primary goals for the platform UI is to provide efficient
 interaction with the workspace. In the platform this is promoted by
 saving the state of the workbench when a session ends (the workbench is
@@ -1113,9 +1112,9 @@ TIP: [guideline7.20]*Guideline 7.20* +
 Persist the state of each view between sessions.
 
 
-=== Interaction with Editors
+==== Interaction with Editors
 
-==== Link with Editor
+===== Link with Editor
 Navigation views should support "Link with Editor" on the view menu.
 This feature works on a per-view setting. If it's expected that users
 will toggle it frequently, then it can also go on the toolbar, but this
@@ -1151,12 +1150,12 @@ TIP: [guideline7.21]*Guideline 7.21* +
 Navigation views should support "Link with Editor" on the view menu
 
 
-==== Opening an Editor from a View
+===== Opening an Editor from a View
 There exist two main modes for opening an editor from a view: single
 click and double click mode. Views should show the following behavior
 for opening an editor:
 
-===== Single click open mode
+====== Single click open mode
 
 * file closed
 ** single click opens but does not activate the editor (selects the
@@ -1170,7 +1169,7 @@ the editor if possible)
 ** double click activates the editor (selects the element in the editor
 if possible)
 
-===== Double click open mode
+====== Double click open mode
 
 * file closed
 ** single click does nothing except selecting the element
@@ -1187,7 +1186,7 @@ does not activate it (selects the element in the editor if possible)
 ** double click activates the editor (selects the element in the editor
 if possible)
 
-===== Additional rules
+====== Additional rules
 
 * pressing the the 'Enter' key should do the same as a double click
 * Next (Ctrl+.) / Previous (Ctrl+,) buttons select the next/previous
@@ -1196,7 +1195,7 @@ element in the editor but never activate the editor
 
 '''
 
-== Perspectives
+=== Perspectives
 
 A perspective is a visual container for a set of views and editors
 (parts). Different perspectives can have different sets of views open,
@@ -1262,7 +1261,7 @@ TIP: [guideline8.2]*Guideline 8.2* +
 If you just want to expose a single view, or two, extend an existing
 perspective type.
 
-=== View Layout
+==== View Layout
 
 If the user opens a new perspective, the initial layout of views will be
 defined by the perspective type (i.e., Resource, Java). This layout is
@@ -1315,7 +1314,7 @@ If it is undesirable to have an editor area in a perspective, hide it.
 Do not resize the editor area to the point where it is no longer
 visible.
 
-=== Command Contribution
+==== Command Contribution
 
 The perspective factory may add actions to the File > New, Window > Open
 Perspective , and Window > Show View menus. It is also possible to add
@@ -1353,7 +1352,7 @@ Populate the window menu bar with commands and command sets which are
 appropriate to the task orientation of the perspective, and any larger
 workflow.
 
-=== Opening a Perspective in Code
+==== Opening a Perspective in Code
 
 A command should open a new perspective only if the user explicitly
 states a desire to do so. If the user does not state a desire to do so,
@@ -1401,7 +1400,7 @@ The list of shortcuts added to the New, Open Perspective, and Show View
 menus should be at most 7 plus / minus 2 items.
 
 
-== Windows
+=== Windows
 
 In this section we look at the window menu bar, toolbar, and layout. As
 a plug-in developer, you can contribute actions to the menu bar and
@@ -1411,7 +1410,7 @@ window by defining a __perspective__. In this section we'll look at
 action extension. For more information on perspectives, see
 xref:#_perspectives[Perspectives].
 
-=== Actions
+==== Actions
 
 Each workbench window contains a menu bar and toolbar. These are
 pre-populated by the platform, but a plug-in developer may add
@@ -1538,7 +1537,7 @@ TIP: [guideline9.8]*Guideline 9.8* +
 "Open Object" actions must appear in the Navigate pulldown menu of the
 window.
 
-=== Status Bar
+==== Status Bar
 
 If there is a need for a plug-in to show non-modal contextual
 information in the status bar area, always use the global status bar.
@@ -1548,7 +1547,7 @@ and column number.
 TIP: [guideline9.9]*Guideline 9.9* +
 Always use the global status bar to display status related messages.
 
-== Properties
+=== Properties
 
 A Properties dialog or view is used to view / modify the properties of
 an object which are not visible in the normal presentation of that
@@ -1599,15 +1598,15 @@ TIP: [guideline10.4]*Guideline 10.4* +
 Properties Dialog should contain the superset of items shown in the
 Properties view.
 
-=== Properties View
+==== Properties View
 
-==== Summary
+===== Summary
 
 For consistency and clarity in Properties, use the standard tabbed view
 with proper tab ordering, flexible layout, detailed user assistance,
 accurate multi-selection, and no sub-tabs.
 
-==== Problem Description
+===== Problem Description
 
 Across many Eclipse-based products, the Properties view is being used
 and presented inconsistently. This inconsistency is problematic for
@@ -1615,7 +1614,7 @@ users who use more than one of these products. Moreover, poor choices
 for layout, controls, and labeling can significantly reduce the
 effectiveness and efficiency of a Properties view.
 
-==== Best Practice
+===== Best Practice
 
 Use the standard tabbed view for product consistency.::
 xref:PropertiesView_Figure[xrefstyle=short] below shows an example. Both tabs 
@@ -1665,7 +1664,7 @@ properties can occasionally be confusing even for expert users. Accordingly,
 use Dynamic Help when possible. Field-level Dynamic Help is desirable; 
 otherwise, a backup approach is to provide hover help (tooltips).
 
-==== Tips and Tricks
+===== Tips and Tricks
 
 When multiple objects are selected in the editor, follow these
 guidelines.
@@ -1680,18 +1679,18 @@ values using a mixed state.
 object, instead of a multiple-object property sheet for the discrete
 objects.
 
-==== Good Examples
+===== Good Examples
 
 image::images/PropertiesView_Figure1.jpg[id=PropertiesView_Figure,title="A tabbed view with recommended control layout."]
 
 
 
-== Widgets
+=== Widgets
 
 In this section, we will describe some of the recommended designs for
 Standard Windows Toolkit (SWT) widgets.
 
-=== Tree and Table
+==== Tree and Table
 
 For Tree and Table widgets that have a checkbox associated with a cell
 item, users can either select the item or change the checkbox state.

--- a/eclipse_ui_full_checklist.adoc
+++ b/eclipse_ui_full_checklist.adoc
@@ -1,12 +1,11 @@
-= Checklist for Developers
-include::_settings.adoc[]
+== Checklist for Developers
 
 Here is a checklist for developers who are developing UI plugins. This
 _could_ be used for certification purposes.
 
-== General UI Guidelines
+=== General UI Guidelines
 
-=== The Spirit of Eclipse
+==== The Spirit of Eclipse
 
 TIP: [guideline1.1]*Guideline 1.1* +
 Follow and apply good user interface design principles: user in control,
@@ -24,7 +23,7 @@ TIP: [guideline1.4]*Guideline 1.4* +
 If you have an interesting idea, work with the Eclipse community to make
 Eclipse a better platform for all.
 
-=== Capitalization
+==== Capitalization
 
 
 TIP: [guideline1.5]*Guideline 1.5* +
@@ -41,11 +40,11 @@ window, including those for check boxes, radio buttons, group labels,
 and simple text fields. Capitalize the first letter of the first word,
 and any proper names such as the word Java.
 
-=== Language
+==== Language
 TIP: [guideline1.7]*Guideline 1.7* +
 Create localized version of the resources within your plug-in.
 
-=== Error Handling
+==== Error Handling
 TIP: [guideline1.8]*Guideline 1.8* +
 When an error occurs which requires either an explicit user input or
 immediate attention from users, communicate the occurrence with a modal
@@ -56,9 +55,9 @@ If a programming error occurs in the product, communicate the occurrence
 with a dialog, and log it.
 
 
-== UI Graphics
+=== UI Graphics
 
-=== Design
+==== Design
 TIP: [guideline2.1]*Guideline 2.1* +
 Follow the visual style established for Eclipse UI graphics.
 
@@ -82,7 +81,7 @@ Use the design templates for creating and maintaining UI graphics to
 facilitate easy file sharing and efficient production of a large set of
 graphics.
 
-=== Specifications
+==== Specifications
 
 TIP: [guideline2.7]*Guideline 2.7* +
 Use the file format specified for the graphic type.
@@ -98,7 +97,7 @@ TIP: [guideline2.10]*Guideline 2.10* +
 Cut the graphics with the specific placement shown to ensure alignment
 in the user interface.
 
-=== Implementation
+==== Implementation
 
 TIP: [guideline2.11]*Guideline 2.11* +
 Use the cutting actions provided to increase the speed and efficiency of
@@ -136,9 +135,9 @@ in one, or few, first level user interface directories.
 TIP: [guideline2.20]*Guideline 2.20* +
 Use the active, enabled, and disabled states provided.
 
-== Component Development
+=== Component Development
 
-=== Commands
+==== Commands
 
 TIP: [guideline3.1]*Guideline 3.1* +
 Each command must have a label, tool tip, and full color image. The
@@ -161,7 +160,7 @@ Command enablement should be quick. If command enablement cannot be
 quick, enable the command optimistically and display an appropriate
 message if the command is invoked, but cannot be completed.
 
-=== Dialogs
+==== Dialogs
 
 TIP: [guideline4.1]*Guideline 4.1*
 When a dialog opens, set the initial focus to the first input control in
@@ -172,7 +171,7 @@ TIP: [guideline4.2]*Guideline 4.2* +
 Slush Bucket widget (or Twin Box) should flow from left to right with
 the source objects on the left hand side. It should have the >, >,
 
-=== Wizards
+==== Wizards
 
 TIP: [guideline5.1]*Guideline 5.1* +
 Use a wizard for any task consisting of many steps, which must be
@@ -225,7 +224,7 @@ Use the term "Project name" for the input field label when the item must
 be a Project; otherwise, use the term "Folder name". Do not qualify the
 term.
 
-=== Editors
+==== Editors
 
 TIP: [guideline6.1]*Guideline 6.1* +
 Use an editor to edit or browse a file, document, or other primary
@@ -352,7 +351,7 @@ should be prompted to either override the changes made outside of the
 workbench, or back out of the Save operation when the Save command is
 invoked in the editor.
 
-=== Views
+==== Views
 
 TIP: [guideline7.1]*Guideline 7.1* +
 Use a view to navigate a hierarchy of information, open an editor, or
@@ -430,7 +429,7 @@ Persist the state of each view between sessions.
 TIP: [guideline7.21]*Guideline 7.21* +
  Navigation views should support "Link with Editor" on the view menu
 
-=== Perspectives
+==== Perspectives
 
 TIP: [guideline8.1]*Guideline 8.1* +
 Create a new perspective type for long lived tasks, which involve the
@@ -478,7 +477,7 @@ TIP: [guideline8.10]*Guideline 8.10* +
 The list of shortcuts added to the New, Open Perspective, and Show View
 menus should be at most 7 plus / minus 2 items.
 
-=== Windows
+==== Windows
 
 TIP: [guideline9.1]*Guideline 9.1* +
 Use an Action Set to contribute actions to the window menu bar and
@@ -514,7 +513,7 @@ window.
 TIP: [guideline9.9]*Guideline 9.9* +
 Always use the global status bar to display status related messages.
 
-=== Properties
+==== Properties
 
 TIP: [guideline10.1]*Guideline 10.1* +
 Use the Properties view to edit the properties of an object when quick
@@ -532,7 +531,7 @@ TIP: [guideline10.4]*Guideline 10.4* +
 Properties Dialog should contain the superset of items shown in the
 Properties view.
 
-=== Widgets
+==== Widgets
 
 TIP: [guideline11.1]*Guideline 11.1* +
 For Tree and Table widgets that have a checkbox associated with a cell
@@ -541,7 +540,7 @@ check state of the selected item. However, the current selection should
 be set to a given item when its check state is changed.
 
 
-== Standard Components
+=== Standard Components
 
 TIP: [guideline12.1]*Guideline 12.1* +
 If appropriate, add actions to standard components of Eclipse using the
@@ -551,7 +550,7 @@ TIP: [guideline12.2]*Guideline 12.2* +
 If you subclass or copy any of the standard components, always carry
 over the standard components' characteristics.
 
-=== The Navigator View
+==== The Navigator View
 
 TIP: [guideline13.1]*Guideline 13.1* +
 Add actions to the Navigator View menu, toolbar, and context menu using
@@ -566,7 +565,7 @@ TIP: [guideline13.3]*Guideline 13.3* +
 Use a "Navigate -> Show In Navigator" command in each view, to link
 resources back to the Navigator.
 
-=== The Tasks View
+==== The Tasks View
 
 TIP: [guideline14.1]*Guideline 14.1* +
 Add markers (tasks, errors and warnings) to the Tasks view using the
@@ -588,7 +587,7 @@ TIP: [guideline14.5]*Guideline 14.5* +
 Support F1 keyboard command and link it to an infopop that gives a
 detailed description of the selected item in the Task view.
 
-=== The Preference Dialog
+==== The Preference Dialog
 
 TIP: [guideline15.1]*Guideline 15.1* +
 Global options should be exposed within the Preferences Dialog.
@@ -613,7 +612,7 @@ existing categories for a new plug-in first, before considering the
 creation of a new category.
 
 
-== Flat Look Design
+=== Flat Look Design
 
 TIP: [guideline16.1]*Guideline 16.1* +
 Use Flat Look design for user scenarios that involves extensive property
@@ -628,14 +627,14 @@ Use grouping elements corresponding to tabs in the Flat Look content
 editor for the organization of the tree view in outline view.
 
 
-== The Tao of Resource
+=== The Tao of Resource
 
 TIP: [guideline17.1]*Guideline 17.1* +
 Expose the resource for resource equivalent model objects using an
 IContributorResourceAdapter.
 
 
-== Accessibility
+=== Accessibility
 
 TIP: [guideline18.1]*Guideline 18.1* +
 All of the features provided by a tool should be accessible using a

--- a/flat_look_design.adoc
+++ b/flat_look_design.adoc
@@ -1,5 +1,4 @@
-= Flat Look Design
-include::_settings.adoc[]
+== Flat Look Design
 
 The Eclipse platform provides a Web user interface, also known as Flat
 Look, design alternative for implementing content editors. For example,
@@ -46,7 +45,7 @@ sections, controls, etc. for keyboard navigation.
 
 image::images/Flatlook5.gif[flatlook5,title="flatlook5"]
 
-== Editor and Outline View Interaction
+=== Editor and Outline View Interaction
 
 Plug-ins that use Flat Look design for content editor should provide
 support for full two way interactions between the editor and outline

--- a/general_ui_guidelines.adoc
+++ b/general_ui_guidelines.adoc
@@ -1,5 +1,4 @@
-= General UI Guidelines
-include::_settings.adoc[]
+== General UI Guidelines
 
 
 This document defines UI guidelines that are unique and specific to the
@@ -26,7 +25,7 @@ directness, consistency, forgiveness, feedback, aesthetics, and
 simplicity.
 
 
-== The Spirit of Eclipse
+=== The Spirit of Eclipse
 
 At its heart, Eclipse is a platform for tool plug-ins. These plug-ins
 may be developed by a single team or by a partnership of teams, or the
@@ -82,7 +81,7 @@ TIP: [guideline1.4]*Guideline 1.4* +
 If you have an interesting idea, work with the Eclipse community to make
 Eclipse a better platform for all.
 
-== Capitalization
+=== Capitalization
 
 Consistent capitalization of text within a plug-in leads to a more
 polished feel, and greater perception of quality. Within a dialog or
@@ -107,7 +106,7 @@ window, including those for check boxes, radio buttons, group labels,
 and simple text fields. Capitalize the first letter of the first word,
 and any proper names such as the word Java.
 
-== Language
+=== Language
 Eclipse is available on a variety of different platforms, in a variety
 of locales. In reflection of the different languages and numeric formats
 in each, a localization strategy should be adopted for the text and
@@ -121,7 +120,7 @@ and more information.
 TIP: [guideline1.7]*Guideline 1.7* +
 Create localized version of the resources within your plug-in.
 
-== Error Handling
+=== Error Handling
 
 If an error occurs in Eclipse, the appropriate response will be
 dependent on the context of the error.

--- a/index.adoc
+++ b/index.adoc
@@ -1,5 +1,6 @@
 = Eclipse UI Guidelines
 include::_settings.adoc[]
+:toc: left
 
 UI Best Practices Working Group
 {version}
@@ -190,43 +191,27 @@ sections.
 
 == Content
 
-- xref:top_ten_lists.adoc[*Quick Checklists and Top Ten Does and Dont's*] +
-  Shortlist of the most relevant and easy to apply Eclipse User Interface 
-  Guidelines and their violations. 
+// don't delete the empty lines between the includes
+// otherwise different chapter text might be joined together by the processor
+include::top_ten_lists.adoc[]
    
-- xref:general_ui_guidelines.adoc[*General UI Guidelines*] +
-  General guidelines for developing Eclipse based user interfaces and Eclipse 
-  extensions.   
+include::general_ui_guidelines.adoc[]
 
-- xref:ui_graphics.adoc[*UI Graphics*] +
-  Guidelines for developing and using UI graphics (i.e. icons, images, banners).   
+include::ui_graphics.adoc[]
 
-- xref:component_dev.adoc[*Component Development*] +
-  Guidelines for the correct usage of diverse Eclipse UI components, such as 
-  commands, dialogs, wizards, editors, views, perspectives, windows, properties,
-  and widgets.   
+include::component_dev.adoc[]
 
-- xref:standard_components.adoc[*Standard Components*] +
-  Guidelines for the standard components which ship with Eclipse.   
+include::standard_components.adoc[]
 
-- xref:flat_look_design.adoc[*Flat Look Design*] +
-  Design alternative for implementing content editors.   
+include::flat_look_design.adoc[]
 
-- xref:tao_of_resource.adoc[*The Tao of Resource*] +
-  Resources as the common medium for integration between plugins and external 
-  tools.   
+include::tao_of_resource.adoc[]
 
-- xref:accessibility.adoc[*Accessibility*] +
-  Guidelines for making UI accessible for different user groups with different 
-  needs.   
+include::accessibility.adoc[]
 
-- xref:best_practices.adoc[*Best Practices*] +
-  Examples of best practices for designing and implementing some common user 
-  interactions within the Eclipse platform.   
+include::best_practices.adoc[]
 
-- xref:eclipse_ui_full_checklist.adoc[*Checklist for Developers*] +
-  Collection of all Eclipse Eclipse User Interface Guidelines.
-
+include::eclipse_ui_full_checklist.adoc[]
 
 == Glossary
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
 				</executions>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
+					<sourceDocumentName>index.adoc</sourceDocumentName>
 					<!-- copy only the images and media directory, otherwise everything from basedir would be copied -->
 					<resources>
 						<resource>

--- a/standard_components.adoc
+++ b/standard_components.adoc
@@ -1,5 +1,4 @@
-= Standard Components
-include::_settings.adoc[]
+== Standard Components
 
 In this section we'll look at the standard components which ship with
 Eclipse. The Eclipse SDK contains a number of views, including the
@@ -23,13 +22,13 @@ TIP: [guideline12.2]*Guideline 12.2* +
 If you subclass or copy any of the standard components, always carry
 over the standard components' characteristics.
 
-== The Navigator View
+=== The Navigator View
 
 The Navigator is used to navigate the workspace, create new resources,
 modify resources, and open an editor on a resource. Plug-in developers
 may contribute new actions to the menu, toolbar, and context menu.
 
-=== Adding Actions
+==== Adding Actions
 
 This is done by adding an extension to the plug-in registry.
 
@@ -83,7 +82,7 @@ Use the attributes defined in IResourceActionFilter.java and
 IProjectActionFilter.java to control the visibility of context menu
 actions in the Navigator.
 
-=== Integration with Other Views and Editors
+==== Integration with Other Views and Editors
 
 In Eclipse, the use of a "Navigate -> Show In" command is a common way
 to link the selection in one view to the input of another. For instance,
@@ -102,7 +101,7 @@ TIP: [guideline13.3]*Guideline 13.3* +
 Use a "Navigate -> Show In Navigator" command in each view, to link
 resources back to the Navigator.
 
-== The Tasks View
+=== The Tasks View
 
 The Tasks view is used to display the current tasks, errors and warnings
 in the workspace. A plug-in developer may contribute new tasks, errors,
@@ -111,7 +110,7 @@ those objects. You can also contribute new actions to the menu, toolbar,
 and context menu. This is done by adding an extension to the plug-in
 registry.
 
-=== Adding Tasks
+==== Adding Tasks
 
 A new task, error or warning can be created using the Marker Manager
 services from the Core Resources Management plugin.
@@ -129,7 +128,7 @@ TIP: [guideline14.2]*Guideline 14.2* +
 The description text of each marker should be short and concise, so that
 it will fit in the status line of Eclipse.
 
-=== Adding Actions
+==== Adding Actions
 
 You can contribute new actions to the menu, toolbar, and context menu.
 This is done by adding an extension to the plug-in registry.
@@ -164,7 +163,7 @@ TIP: [guideline14.4]*Guideline 14.4* +
 Use the attributes defined in IMarkerActionFilter.java to control the
 visibility of context menu actions in the Tasks view.
 
-=== Integration with Other Views and Editors
+==== Integration with Other Views and Editors
 
 In an editor, task objects are commonly used to mark a location within a
 document. Once a task has been created, it appears in the Task view. If
@@ -176,7 +175,7 @@ If appropriate, support for the creation of new task objects in an
 editor should be implemented by the editor. For more information on
 this, see link:#Editors[Editors].
 
-=== Adding F1 Help to Task View
+==== Adding F1 Help to Task View
 
 Plug-ins should support F1 keyboard command and link it to an infopop
 that gives a detailed description of the selected item in the Task view.
@@ -185,12 +184,12 @@ TIP: [guideline14.5]*Guideline 14.5* +
 Support F1 keyboard command and link it to an infopop that gives a
 detailed description of the selected item in the Task view.
 
-== Selection Dialogs
+=== Selection Dialogs
 
 When you want the user to select items from a given list of items, you
 can use the standard selection dialogs available in Eclipse.
 
-=== ContainerSelectionDialog
+==== ContainerSelectionDialog
 
 Use
 http://help.eclipse.org/ganymede/topic/org.eclipse.platform.doc.isv/reference/api/org/eclipse/ui/dialogs/ContainerSelectionDialog.html[ContainerSelectionDialog]
@@ -206,7 +205,7 @@ dialog.open();
 You can restrict the resource to be within a project/folder by passing
 the respective object as the second parameter for the constructor.
 
-=== ResourceSelectionDialog
+==== ResourceSelectionDialog
 
 The ContainerSelectionDialog allowed you to select only one resource
 that too it should be a container. If you want to select multiple
@@ -221,7 +220,7 @@ dialog.setTitle("Resource Selection");
 dialog.open();
 ----
 
-=== ResourceListSelectionDialog
+==== ResourceListSelectionDialog
 
 The ResourceSelectionDialog is good when you want to present the entire
 set of resources under a parent and allow the user to select multiple
@@ -236,7 +235,7 @@ dialog.setTitle("Resource Selection");
 dialog.open();
 ----
 
-=== ElementListSelectionDialog
+==== ElementListSelectionDialog
 
 The above Dialogs are good to selecting workspace resources. But what if
 I have some elements on my own and I want to select from that? The first
@@ -255,7 +254,7 @@ dialog.setElements(new Object[] { "one", "two", "three" });
 dialog.open();
 ----
 
-=== ListSelectionDialog
+==== ListSelectionDialog
 
 If you want the user to select multiple elements from the given set,
 then
@@ -272,7 +271,7 @@ dlg.setTitle("Element Selection");
 dlg.open();
 ----
 
-=== CheckedTreeSelectionDialog
+==== CheckedTreeSelectionDialog
 
 If you have your items in a tree structure and want to select few
 elements from them, then
@@ -289,7 +288,7 @@ dialog.setInput(getInput());
 dialog.open();
 ----
 
-=== ElementTreeSelectionDialog
+==== ElementTreeSelectionDialog
 
 http://help.eclipse.org/ganymede/topic/org.eclipse.platform.doc.isv/reference/api/org/eclipse/ui/dialogs/ElementTreeSelectionDialog.html[ElementTreeSelectionDialog]
 is the same as the CheckedTreeSelectionDialog except that it will allow
@@ -305,7 +304,7 @@ dialog.setInput(getInput());
 dialog.open();
 ----
 
-=== FilteredItemsSelectionDialog
+==== FilteredItemsSelectionDialog
 
 Have you used the Open Type (Ctrl + Shift + T) or Open Resource
 (Ctrl+Shift+R) dialog? Its similar to the ElementListSelectionDialog,
@@ -317,7 +316,7 @@ abstract class
 http://help.eclipse.org/ganymede/topic/org.eclipse.platform.doc.isv/reference/api/org/eclipse/ui/dialogs/FilteredItemsSelectionDialog.html[FilteredItemsSelectionDialog]
 and provide the necessary implementation.
 
-== The Preference Dialog
+=== The Preference Dialog
 
 The Preference Dialog is used to edit the global preference for a
 feature in the workbench.
@@ -341,7 +340,7 @@ TIP: [guideline15.2]*Guideline 15.2* +
 Expose the preferences for a particular view, editor or window in the
 view itself, via a menu or tool item.
 
-=== Preference Page Design
+==== Preference Page Design
 
 In the simplest case, any plug-in which needs to expose an option to the
 user will define a single preference page. This preference page should
@@ -381,7 +380,7 @@ Attempt to integrate plug-in preferences, wizards, and views into
 existing categories for a new plug-in first, before considering the
 creation of a new category.
 
-== The Outline View
+=== The Outline View
 
 In Eclipse, there is a special relationship between an editor and the
 Outline view. When an editor is opened, the Outline view will connect to
@@ -394,7 +393,7 @@ If you are an editor developer, the relationship between an editor and
 the Outline view is important. For more information on the collaboration
 between these two, see xref:component_dev.adoc#editors[Editors].
 
-== The Properties View
+=== The Properties View
 
 The Properties view shows the properties for the active part in the
 workbench, or the selection within that part. These properties are
@@ -410,7 +409,7 @@ one object to another quickly.
 For more information on the use of the Properties view, or Properties
 dialog, refer to xref:component_dev.adoc#properties[Properties].
 
-== The Bookmarks View
+=== The Bookmarks View
 
 The Bookmarks view is used to bookmark files, and open them quickly. A
 plug-in developer may contribute new bookmarks to the workspace, and
@@ -427,14 +426,14 @@ If appropriate, support for the creation of new bookmark objects should
 be implemented by the editor. For more information on this, see
 xref:component_dev.adoc#_editors[Editors].
 
-== The Text Editor
+=== The Text Editor
 
 The Text Editor is commonly used to edit text files. A plug-in developer
 can contribute new actions to the menu, toolbar, and context menu. This
 is done by adding an extension to the plug-in registry. For more
 information on this, see xref:component_dev.adoc#editors[Editors].
 
-== The Resource Perspective
+=== The Resource Perspective
 
 The Resource perspective contains a Navigator, Outline, Task view, and
 editor area. Plug-in developers may contribute a new command, action

--- a/tao_of_resource.adoc
+++ b/tao_of_resource.adoc
@@ -1,5 +1,4 @@
-= The Tao of Resource
-include::_settings.adoc[]
+== The Tao of Resource
 
 In Eclipse, the notion of a tool disappears. In its place, is the idea
 of a universal tool platform - an open, extensible IDE - where tool

--- a/top_ten_lists.adoc
+++ b/top_ten_lists.adoc
@@ -1,7 +1,6 @@
-= Quick Checklists and Top Ten Does and Dont's
-include::_settings.adoc[]
+== Quick Checklists and Top Ten Does and Dont's
 
-== Quick UI Checklist
+=== Quick UI Checklist
 
 This is is a shortlist of the most relevant and easy to apply Eclipse 
 xref:index.adoc[*User Interface Guidelines*].  
@@ -10,7 +9,7 @@ then use the xref:eclipse_ui_full_checklist.adoc[Full Checklist]
 for additional guidance.  For comments please use the 
 https://github.com/eclipse-platform/ui-best-practices/issues[UI Best Practices GitHub Issues].
 
-=== Views & Editors
+==== Views & Editors
 
 . Put only the most commonly used commands on the view toolbar. 
   Any command on a toolbar must also appear in a menu, either the window menu, 
@@ -33,7 +32,7 @@ https://github.com/eclipse-platform/ui-best-practices/issues[UI Best Practices G
 . Persist the state of each view between sessions 
   (xref:index.adoc#guideline7.20[Guideline 7.20]).
 
-=== Wizards & Dialogs
+==== Wizards & Dialogs
 
 . Start a wizard with a prompt, not an error message. 
   (xref:index.adoc#guideline5.3[Guideline 5.3])
@@ -48,7 +47,7 @@ https://github.com/eclipse-platform/ui-best-practices/issues[UI Best Practices G
 . Use a Browse Button whenever an existing object is referenced in a wizard. 
   (xref:index.adoc#guideline5.8[Guideline 5.8])
 
-=== Workbench & Preferences
+==== Workbench & Preferences
 
 . Use Headline style capitalization for menus, tooltip and all titles, 
   including those used for windows, dialogs, tabs, column headings and push buttons 
@@ -69,7 +68,7 @@ https://github.com/eclipse-platform/ui-best-practices/issues[UI Best Practices G
   The root preference page should not be blank. 
   (xref:index.adoc#guideline2.2[Guideline 2.2])
 
-== Top Ten Lists
+=== Top Ten Lists
 
 This is a starter set of top ten Eclipse UI Guidelines and Violations.
 The purpose of these lists is to be a starting point for Eclipse UI
@@ -79,7 +78,7 @@ follow and to avoid, respectively.
 To see all considerations to-date go to the
 link:https://wiki.eclipse.org/Top_Ten_Lists_Working_Page[Top Ten Lists Working Page].
 
-=== Top Ten Eclipse UI Guidelines
+==== Top Ten Eclipse UI Guidelines
 
 . Use the Eclipse look and feel if extending or plugging into Eclipse
 . Use common SWT controls to get what SWT offers for cross-platform adaptability
@@ -93,7 +92,7 @@ link:https://wiki.eclipse.org/Top_Ten_Lists_Working_Page[Top Ten Lists Working P
 . Use quick fix and quick assist mechanisms
 . Reserve time for "polish"
 
-=== Top Ten Eclipse UI Violations
+==== Top Ten Eclipse UI Violations
 
 . Low quality graphics or not consistent with the Eclipse style
 . Poorly organized or sized dialogs and wizards

--- a/ui_graphics.adoc
+++ b/ui_graphics.adoc
@@ -1,7 +1,6 @@
-= UI Graphics
-include::_settings.adoc[]
+== UI Graphics
 
-== Overview
+=== Overview
 
 The following guide covers user interface (UI) graphics for Eclipse-based tools. 
 All visual user interface elements created for Eclipse-based tools follow a 
@@ -11,7 +10,7 @@ should follow these guidelines to help ensure consistency of visual user
 interface elements. Consistency includes visual style, meaning, and 
 implementation conventions.
 
-=== Audience
+==== Audience
 
 These guidelines are for anyone creating Eclipse style user interface
 graphics or seeking best practices for their use. This is not a how-to
@@ -21,12 +20,12 @@ will be interested in the Design, Specifications, and Implementation
 sections. If you are a Developer, the Specifications and Implementations
 sections will be of most value to you.
 
-== Design
+=== Design
 
 This section provides guidance and tools for creating Eclipse style
 icons and wizard graphics.
 
-=== Style & Design
+==== Style & Design
 
 This section covers style characteristics and gives guidance for
 designing effective Eclipse user interface graphics including topics
@@ -40,7 +39,7 @@ elements. If designing an icon or wizard graphic from the start,
 consider the underlying concept and how it can best be represented.
 There might be an existing metaphor to appropriately convey the concept.
 
-==== Metaphor
+===== Metaphor
 
 The purpose of a metaphor is to create meaning. A metaphor will be
 meaningful if it is based on ideas the audience is already familiar
@@ -52,9 +51,9 @@ store project-related information. Since many concepts already have
 associated metaphors, use the existing metaphors, and when the concept
 allows, create new representations that extend the metaphor.
 
-==== Icons
+===== Icons
 
-===== Style characteristics
+====== Style characteristics
 
 The icons should have a clean elegant feel with rich but subtle color
 and lighting. They are rendered as if viewed directly from in front, but
@@ -134,7 +133,7 @@ Here are the same icons rendered in the more low-key toolbar style:
 +
 image::images/des_styl_types_tool.png[des_styl_types_tool]
 
-===== Composition
+====== Composition
 Aim for simplicity. Bring focus to the primary function or object within
 an icon by using different visual cues, such as color, contrast,
 lighting, size and location to differentiate elements. To improve
@@ -228,7 +227,7 @@ Stopping the server will show the blue square stop action on the right
   of the server object. +
 image:images/des_styl_state-stop.png[des_styl_state-stop]
 
-===== Color Palette & Themes
+====== Color Palette & Themes
 
 An entire set of graphical elements, such as icons, wizards and user
 assistance graphics, requires a consistent, family-like appearance
@@ -300,7 +299,7 @@ image::images/ddes_styl_beige.png[ddes_styl_beige]
   not limited to these two object types, beige is usually reserved for
   placeholder or unrealized objects.
 
-===== Tips and Tricks
+====== Tips and Tricks
 
 . *Use color from existing graphics* to quickly make graphics that are 
   consistent with the Eclipse style without having to use the palette directly, 
@@ -391,9 +390,9 @@ Related Information::
 + 
 The GIMP User Manual is available online at: http://www.gimp.org/docs/
 
-==== Wizard Banner Graphics
+===== Wizard Banner Graphics
 
-===== Style characteristics
+====== Style characteristics
 
 Like the Eclipse-style icons, wizard banner graphics have a clean
 presentation that is achieved by using rich but not overpowering color,
@@ -467,7 +466,7 @@ Here is an example of a flat outline used to define the edges of a
   wizard graphic: + 
 image:images/des_styl_wiz_outline2.png[des_styl_wiz_outline2,title="fig:des_styl_wiz_outline2"]
 
-===== Composition
+====== Composition
 
 Composition of elements within wizard graphics follows most of the same
 practices described for icons. There are a few wizard-specific
@@ -492,7 +491,7 @@ States:: of objects, once in the wizard, change to what the state will
   when in a wizard banner graphic because it will be open once in a
   treeview or list view.
 
-===== Color
+====== Color
 
 Wizard graphic colors are based on the icons that launch them. The
 colors used to create a toolbar wizard icon, for instance, should be the
@@ -565,7 +564,7 @@ Follow the visual style established for Eclipse UI graphics.
 TIP: [guideline2.2]*Guideline 2.2 (3.x update)* +
 Use a common color palette as the basis for creating graphical elements.
 
-=== Consistency & Reuse
+==== Consistency & Reuse
 
 This section encourages consistency and reuse of existing graphical
 elements, and shows the core icon and wizard concepts currently in the
@@ -582,7 +581,7 @@ understanding of concepts across the tools, and to minimize confusion,
 we encourage you to re-use Eclipse-style graphical elements whenever
 possible.
 
-==== Re-using graphical elements
+===== Re-using graphical elements
 
 A great many icons and wizard graphics have already been created in the
 Eclipse visual style, so there is a good chance that the elements you
@@ -593,14 +592,14 @@ consistent meaning is maintained. A more extensive collection of common
 visual elements can be found on the xref:#_common_elements[Common
 Elements] page.
 
-==== Core icon concepts
+===== Core icon concepts
 
 image::images/des_cons_core-icons.png[des_cons_core-icons]
 
 Click link:media/core_icon_concepts.zip[*here*] or on the image above to
 download the "core_icon_concepts.psd".
 
-==== Core wizard graphic concepts
+===== Core wizard graphic concepts
 
 image::images/des_cons_core-wiz.png[des_cons_core-wiz]
 
@@ -612,7 +611,7 @@ TIP: [guideline2.3]*Guideline 2.3* +
 Re-use the core visual concepts to maintain consistent representation
 and meaning across Eclipse plug-ins.
 
-=== Common Elements
+==== Common Elements
 
 This section provides a library of graphical elements that have already
 been developed for Eclipse-based tools. This extensive selection of
@@ -622,7 +621,7 @@ conjunction with the core concepts shown in the Consistency & Reuse
 section, this library will enable efficient creation of graphical
 elements and promote consistency throughout the user interface.
 
-==== Icon elements
+===== Icon elements
 
 image::images/des_common_icons.png[des_common_icons]
 
@@ -631,7 +630,7 @@ Click link:media/common_icon_elements.zip[ *here*] to download the
   the "common_icon_elements_eclipse-tools.psd" file for a subset of
   icons related to Eclipse-based tools.
 
-==== Wizard elements
+===== Wizard elements
 
 image::images/des_common_wiz.png[des_common_wiz]
 
@@ -644,27 +643,27 @@ TIP: [guideline2.4]*Guideline 2.4* +
 Re-use existing graphics from the Common Elements library or other
 Eclipse-based plugins.
 
-=== States
+==== States
 This section describes the use of enabled and disabled icons in the user
 interface. It also provides instructions and an automated action set for
 creating the disabled state of your enabled color icons, a useful tool
 when producing a large volume of icons.
 
-==== Icon States
+===== Icon States
 
 This section describes the use of enabled and disabled icons in the user
 interface. It also provides instructions and an automated action set for
 creating the disabled state of your enabled color icons, a useful tool
 when producing a large volume of icons.
 
-===== Enabled state
+====== Enabled state
 The enabled icon state is the color version of all toolbar, toolbar
 wizard, and local toolbar icons. This state indicates that a command
 is active and available for use. Information on creating the enabled
 color version of these icons can be found under
 *link:#_style_design[Style & Design]* above.
 
-===== Disabled state
+====== Disabled state
 The disabled icon state is a dimmed version of the enabled color
   toolbar, toolbar wizard, and local toolbar icons. This state indicates
   that a command is inactive and not available for use. The following
@@ -682,7 +681,7 @@ NOTE: It is important to implement the graphical versions of the
   are not consistent with the majority of other tools that use the
   graphical versions.
 
-===== Creating the disabled icon state
+====== Creating the disabled icon state
 To create this state, you will use the
   "eclipse_disabledrender_R3V6.atn" action in the Eclipse-style Actions
   palette. Click link:media/eclipse-style_actions.zip[*here*] to download
@@ -713,7 +712,7 @@ Here is what the "Create Disabled State" action looks like in the
 
 image::images/des_states_disabled-atn.png[des_states_disabled-atn,title="fig:des_states_disabled-atn"]
 
-===== Toggled states
+====== Toggled states
 The toggled state is used on toolbars, local toolbars, and in menus.
   On toolbars and local toolbars, a toggle is represented by a button
   with two physical positions—up and down—which define a state, most
@@ -730,7 +729,7 @@ Sometimes a toggle is not a simple on/off state. For example, there
   buttons sit beside one another on the local toolbar and when one is
   on, the other is off.
 
-===== Opened and closed folder states
+====== Opened and closed folder states
 In the treeview, ideally, folders would be closed when the -/+ widget
   beside the folder icon is in a closed state, as in [+], and opened
   when the -/+ widget beside the folder icon is in an opened state, as
@@ -761,7 +760,7 @@ TIP: [guideline2.5]*Guideline 2.5* +
 Create and implement the graphical versions of the disabled state for
 toolbar and local toolbar icons.
 
-=== Templates
+==== Templates
 
 This section provides design files for producing different types of user
 interface graphics. A description of the templates and guidance on how
@@ -779,7 +778,7 @@ Maintaining the simple structure of the templates will facilitate easy
 file sharing and efficient production of a large set of graphics for one
 tool.
 
-==== Icon Design Template
+===== Icon Design Template
 
 . *Populating the template:* Fill out the
 link:media/eclipse3.0_ui_design_resources.zip[*icon_design_template.psd*]
@@ -832,7 +831,7 @@ required or entirely new icons may be requested. To keep track of which
 icons and their instances need to be cut or re-cut, a red box can be
 placed around each, using the *cut or re-cut (red)* layer.
 
-==== Wizard Design Template
+===== Wizard Design Template
 
 . *Populating the vector-based template:* Fill out the vector-based
 template 
@@ -897,17 +896,17 @@ Use the design templates for creating and maintaining UI graphics to
 facilitate easy file sharing and efficient production of a large set of
 graphics.
 
-== Specifications
+=== Specifications
 
 This section details technical information you will need to design and
 prepare your Eclipse-style graphics for implementation.
 
-=== File Formats
+==== File Formats
 
 This section lists and describes the graphic file formats used for the
 different graphic types.
 
-==== GIF - Graphics Interchange Format
+===== GIF - Graphics Interchange Format
 
 GIF images are raster-based, can have transparency, and tend to use a
 small amount of memory and disk space. Each GIF file contains a color
@@ -925,7 +924,7 @@ because such icons contain only 256 pixels. The GIF file palette
 limitation is, however, something to be aware of when creating larger
 images.
 
-==== PNG - Portable Network Graphics
+===== PNG - Portable Network Graphics
 
 PNG is a bitmapped image format that employs lossless data compression.
 PNG was created to improve upon and replace the GIF format, as an
@@ -951,7 +950,7 @@ tooling:
 * Progress Indicator
 * Miscellaneous (there might be exceptions)
 
-==== SVG - Scalable Vector Graphics format
+===== SVG - Scalable Vector Graphics format
 
 SVG is a language for describing both two-dimensional and animated
 vector-based graphics in XML. One of its distinguishing attributes is
@@ -969,7 +968,7 @@ In designing graphics for SVG output, use a minimal number of elements
 in each image, especially for small 16 x 16 icons. This will help ensure
 image clarity, and fewer elements will keep the file size small.
 
-==== BMP - Bit map format
+===== BMP - Bit map format
 
 BMP is the standard Microsoft Windows raster image format.
 
@@ -979,7 +978,7 @@ tooling:
 * Pointer
 * Cursor
 
-==== ICO - Icon format
+===== ICO - Icon format
 
 ICO format is used on the Microsoft Windows operating system and is
 required for product install and launch icons, including desktop,
@@ -989,11 +988,11 @@ ICO is used for the following type of graphics in Eclipse-based tooling:
 
 * Product icons (Windows)
 
-==== ICNS - Mac Icon format
+===== ICNS - Mac Icon format
 
 * Product icons (Mac)
 
-==== XPM - X PixMap format
+===== XPM - X PixMap format
 
 XPM is an ASCII image format that supports transparent color. This image
 format is used on Linux and is required for product install and launch
@@ -1007,7 +1006,7 @@ XPM is used for the following type of graphics in Eclipse-based tooling:
 TIP: [guideline2.7]*Guideline 2.7* +
 Use the file format specified for the graphic type.
 
-=== Graphic Types
+==== Graphic Types
 
 This section describes the different types of graphics that are used in
 Eclipse-based tools, and where they are located within the user
@@ -1023,7 +1022,7 @@ Placement]. The following graphic types are described below:
 
 image::images/spec_type_icon.png[spec_type_icon]
 
-==== Product
+===== Product
 The Product icon, also known as the Application icon, represents the
   branding of the product and is always located on the far left of the
   window title bar before the perspective, document, and product name.
@@ -1038,7 +1037,7 @@ image::images/spec_type_prod.png[spec_type_prod]
 [horizontal]
 Format:: ICO (Windows), ICNS (Mac), XPM (Linux)
 
-==== Perspective
+===== Perspective
 Perspective icons represent different working environments called
   "Perspectives". Each perspective is a set of views and content editors
   with a layout conducive to the tasks associated with that environment.
@@ -1057,7 +1056,7 @@ Folder name:: view16
 Size:: 16 x 16 pixels
 Format:: PNG
 
-==== Fast View
+===== Fast View
 Fast View icons allow users to quickly display different views that
   have been created as fast views. These icons are by default located in
   the bottom left of the user interface and have a horizontal
@@ -1073,7 +1072,7 @@ Folder name:: view16
 Size:: 16 x 16 pixels
 Format:: PNG
 
-==== Toolbar
+===== Toolbar
 Toolbar icons are located on the main toolbar across the top of the
   workbench. They represent actions, and will invoke a command, either
   globally or within the editor.
@@ -1086,7 +1085,7 @@ Folder names:: etool16 and dtool16
 Size:: 16 x 16 pixels
 Format:: PNG
 
-==== Toolbar Wizard
+===== Toolbar Wizard
 Toolbar wizard icons are found on the main toolbar across the top of
   the workbench as well as in the New wizard dialog list. Selecting one
   of these icons will launch a wizard. The most common type of toolbar
@@ -1104,7 +1103,7 @@ Folder names:: etool16 and dtool16
 Size:: 16 x 16 pixels
 Format:: PNG
 
-==== View
+===== View
 View icons are found on the left side of the titlebar of each view
   within the workbench. These icons indicate each view’s function or the
   type of object a view contains.
@@ -1117,7 +1116,7 @@ Folder name:: view16
 Size:: 16 x 16 pixels
 Format:: PNG
 
-==== Local Toolbar
+===== Local Toolbar
 Local toolbar icons are found to the right of the view icon on the
   titlebar of each view within the workbench. They represent actions,
   and invoke commands on objects in only that view. Local toolbar type
@@ -1132,7 +1131,7 @@ Folder names:: elcl16 and dlcl16
 Size:: 16 x 16 pixels
 Format:: PNG
 
-==== Model Object
+===== Model Object
 Model Object icons are found in tree views, list views, and on editor
   tabs within the workbench. They represent objects and sometimes
   states, but not actions. Examples of model object icons are project
@@ -1160,7 +1159,7 @@ Folder name:: obj16
 Size:: 16 x 16 pixels
 Format:: PNG
 
-==== Object Overlay (and Underlay)
+===== Object Overlay (and Underlay)
 Object overlay icons are decorator elements that are used in tree or
   list views. They are appended to model object icons as signifiers of
   an object type, status, attribute, transition state, multiplicity or
@@ -1313,7 +1312,7 @@ Folder name:: ovr16
 Size:: 16 x 16 pixels
 Format:: PNG
 
-====  Table
+=====  Table
 Table icons are a type of model object icon used specifically in
   tables as labels, status indication, or to give additional information
   about the items they accompany in a table row. Although these icons
@@ -1331,7 +1330,7 @@ Size:: They are designed in the 16 x 16 pixel space, but the actual
   image size is no greater than 15 x 14 pixels.
 Format:: PNG
 
-====  Palette
+=====  Palette
 Palette icons are located on the palette and most commonly accompany
   diagrams or some editable canvas space. In this context, palette icons
   are either objects that may be added to the canvas, or tools that may
@@ -1356,7 +1355,7 @@ Size:: Size varies depending on the context of the palette. The
   cases where 32 x 32 pixel icons are used on the palette.
 Format:: PNG
 
-====  Diagram
+=====  Diagram
 Diagram icons come in two subtypes: Canvas and Action Bar. Canvas
   icons are used in the diagram or canvas area. These icons commonly
   represent object types, but can also be used to mark content type or
@@ -1380,7 +1379,7 @@ Size:: Canvas icons may be 16 x 16, 24 x 24, or 32 x 32 pixel in
 Format:: PNG is used for all diagram graphics, except Action Bar
   icons, which are SVG.
 
-==== Progress Indicator
+===== Progress Indicator
 The progress indicator icon is located in lower right of user
   interface to the right of the actual progress indicator, which shows
   the linear progress of a process. As shown in the following image, the
@@ -1394,7 +1393,7 @@ Folder name:: progress
 Size:: 16 x 16 pixels
 Format:: PNG
 
-==== Pointer and Cursor Mask
+===== Pointer and Cursor Mask
 Pointer icons are cursors and each requires a cursor mask. The cursor
   mask is an inverted image, or a complete mask, of the pointer.
 
@@ -1408,7 +1407,7 @@ Folder name:: point
 Size:: 32 x 32 pixels
 Format:: BMP
 
-==== Wizard Banner
+===== Wizard Banner
 Wizard banner graphics are located on the right side of the wizard
   banner. They visually represent the outcome of the wizard, such as a
   new Java class.
@@ -1426,7 +1425,7 @@ TIP: [guideline2.8]*Guideline 2.8* +
 Use the appropriate graphic type in the location it is designed for
 within the user interface.
 
-=== Icon Size & Placement
+==== Icon Size & Placement
 This section shows the final cut size of each of the different types of
 icons, as well as what the placement and drawing area is within the
 allotted space.
@@ -1447,7 +1446,7 @@ single row of empty pixels on all four sides.
 Exceptions to the common 16 x 16 image size are also detailed below. All
 sizes are indicated with width before height.
 
-==== Product
+===== Product
 
 Product icons occupy the full space allotted for all five sizes: 16 x
   16, 24 x 24, 32 x 32, 64 x 64, and 72 x 72 pixels. This shows how the
@@ -1461,7 +1460,7 @@ Product icons occupy the full space allotted for all five sizes: 16 x
 |image:images/spec_size_prod16samp.png[spec_size_prod16samp,title="fig:spec_size_prod16samp"]
 |=======================================================================
 
-==== Perspective and Fast View
+===== Perspective and Fast View
 
 The maximum image size is 16 x 16 pixels, but 15 x 15 is recommended.
   If the image is 15 x 15 or smaller, the empty pixels must be on the
@@ -1477,7 +1476,7 @@ Image size in allotted space
 |image:images/spec_size_perspsamp.png[spec_size_perspsamp,title="fig:spec_size_perspsamp"]
 |=======================================================================
 
-==== View
+===== View
 
 The maximum image size is 16 x 16 pixels, but 15 x 15 is recommended.
   If the image is 15 x 15 or smaller, the empty pixels must be on the
@@ -1491,7 +1490,7 @@ The maximum image size is 16 x 16 pixels, but 15 x 15 is recommended.
 |image:images/spec_size_viewsamp.png[spec_size_viewsamp,title="fig:spec_size_viewsamp"]
 |=======================================================================
 
-==== Toolbar, Toolbar Wizard, and Local Toolbar
+===== Toolbar, Toolbar Wizard, and Local Toolbar
 The maximum image size is 16 x 16 pixels, but 15 x 15 is recommended.
   If the image is 15 x 15 or smaller, the empty pixels must be on the
   left and top, as shown here.
@@ -1504,7 +1503,7 @@ The maximum image size is 16 x 16 pixels, but 15 x 15 is recommended.
 |image:images/spec_size_toolsamp.png[spec_size_toolsamp,title="fig:spec_size_toolsamp"]
 |=======================================================================
 
-==== Model Object
+===== Model Object
 The maximum image size is 16 x 15 pixels, but 15 x 15 is recommended.
   Model Object icons must be no greater than 15 pixels high. The empty
   pixels must be on the left and bottom, as shown here.
@@ -1517,7 +1516,7 @@ The maximum image size is 16 x 15 pixels, but 15 x 15 is recommended.
 |image:images/spec_size_objsamp.png[spec_size_objsamp,title="fig:spec_size_objsamp"]
 |=======================================================================
 
-==== Object Overlay (and Underlay)
+===== Object Overlay (and Underlay)
 Most object overlay icons are a maximum image size of 7 x 8 pixels,
   always centered. There are some exceptions to this size, two of which
   are covered here: the "multiplicity" overlay and the "underlay". The
@@ -1618,7 +1617,7 @@ Example of two stacking Version Control object overlays in place:
 |image:images/spec_size_ovr-undersamp.png[spec_size_ovr-undersamp,title="fig:spec_size_ovr-undersamp"]
 |=======================================================================
 
-==== Table
+===== Table
 
 The maximum image size is 15 x 14 pixels. Table icons must be no
   greater than 14 pixels high. The empty pixels must be on the top,
@@ -1632,7 +1631,7 @@ The maximum image size is 15 x 14 pixels. Table icons must be no
 |image:images/spec_size_tablesamp.png[spec_size_tablesamp,title="fig:spec_size_tablesamp"]
 |=======================================================================
 
-==== Palette
+===== Palette
 *Standard small (16 x 16) palette icon:* The maximum image size is 16
   x 15 pixels, but 15 x 15 is recommended. Palette icons must be no
   greater than 15 pixels high. The empty pixels must be on the left and
@@ -1671,7 +1670,7 @@ The maximum image size is 15 x 14 pixels. Table icons must be no
 |image:images/spec_size_pal32samp.png[spec_size_pal32samp,title="fig:spec_size_pal32samp"]
 |=======================================================================
 
-==== Diagram
+===== Diagram
 *Small (10 x 10) canvas icon:* The maximum image size is 10 x 10
   pixels. The image fills the space as required.
 
@@ -1730,7 +1729,7 @@ The maximum image size is 15 x 14 pixels. Table icons must be no
 |image:images/spec_size_dgm32samp.png[spec_size_dgm32samp,title="fig:spec_size_dgm32samp"]
 |=======================================================================
 
-==== Progress Indicator
+===== Progress Indicator
 
 The maximum image size is 16 x 15 pixels, but 15 x 15 is recommended.
   Progress indicator icons must be no greater than 15 pixels high. The
@@ -1744,7 +1743,7 @@ The maximum image size is 16 x 15 pixels, but 15 x 15 is recommended.
 |image:images/spec_size_progsamp.png[spec_size_progsamp,title="fig:spec_size_progsamp"]
 |=======================================================================
 
-==== Pointer and Cursor Mask
+===== Pointer and Cursor Mask
 
 The final size of the pointer and cursor masks is 32 x 32 pixels. The
   actual image size of the pointer is usually fewer than 20 x 20 pixels,
@@ -1763,7 +1762,7 @@ Pointer and cursor mask image sizes shown in the 32 x 32 pixel space:
 |image:images/spec_size_pointsamp.png[spec_size_pointsamp,title="fig:spec_size_pointsamp"]
 |=======================================================================
 
-==== Wizard Banner
+===== Wizard Banner
 All wizard banner graphics are designed to fit within a specified
   screen space of 75 x 66 pixels on the right side of the wizard banner.
 
@@ -1785,12 +1784,12 @@ TIP: [guideline2.10]*Guideline 2.10* +
 Cut the graphics with the specific placement shown to ensure alignment
 in the user interface.
 
-== Implementation
+=== Implementation
 
 This section provides automated cutting actions, and conventions for
 file and folder naming and structure.
 
-=== Cutting Actions
+==== Cutting Actions
 
 This section describes the macros for cutting icons, icon overlays, and
 wizard banner graphics to get them ready for implementation.
@@ -1813,7 +1812,7 @@ To use these actions, click here to download the
 media:eclipse_cutting_R3V6.zip[eclipse_cutting_R3V6.atn] file, and then
 load it into the Actions Palette.
 
-==== Cutting 16 x 16 Pixel Icons
+===== Cutting 16 x 16 Pixel Icons
 
 1.  Make sure that the pink cut layer is turned on, in the psd file.
 2.  Play the Dupe and Flatten_main file action to create a new, flat
@@ -1833,16 +1832,16 @@ To ensure the last step works properly, make sure the pink cut square
   for each icon is spaced exactly as specified in the
   icon_design_template.psd.
 
-===== Detailed View of Cutting Actions
+====== Detailed View of Cutting Actions
 
 image::images/imp_cut_icons.png[imp_cut_icons]
 
-==== Cutting 7 x 8 Pixel Object Overlay Icons
+===== Cutting 7 x 8 Pixel Object Overlay Icons
 
 Follow the steps as laid out above, except cut the icon at 7 x 8 pixels,
 using the Eclipse icon cuts_overlays action.
 
-==== Cutting Wizard graphics
+===== Cutting Wizard graphics
 
 1.  Ensure that the wizard psd has a path called "wizard cut path" under
 *Paths* tab.
@@ -1868,7 +1867,7 @@ To ensure the last step works properly, make sure each wizard graphic
   is contained in a layer set folder.
 
 
-===== Detailed View of Cutting Actions
+====== Detailed View of Cutting Actions
 
 image::images/imp_cut_wizards.png[imp_cut_wizards,title="fig:imp_cut_wizards"]
 
@@ -1876,7 +1875,7 @@ TIP: [guideline2.11]*Guideline 2.11* +
 Use the cutting actions provided to increase the speed and efficiency of
 cutting a large number of graphics.
 
-=== Naming Conventions
+==== Naming Conventions
 
 This section describes the Eclipse standard for file naming and
 guidelines for using suffixes that will help others quickly identify the
@@ -1886,29 +1885,29 @@ We recommend that you work with your development contact to establish
 file names for each graphic before you begin design work, using the
 following guidelines:
 
-==== Abbreviations
+===== Abbreviations
 
 The file name should be an abbreviation of the full icon name, for
 example, the name for the Create DTD Wizard icon might be abbreviated to
 "CrtDTD".
 
-==== Case
+===== Case
 
 All file names must be in lower case, for example, CrtDTD becomes
 "crtdtd".
 
-==== Character length
+===== Character length
 
 File names should be 10 characters or fewer whenever possible.
 Underscores count as a character.
 
-==== Suffixes
+===== Suffixes
 
 The file name should end with a suffix that describes its location or
 function in the user interface, for example, "crtdtd_wiz.png". See the
 table below for suffix suggestions.
 
-==== Multiple sizes
+===== Multiple sizes
 
 Icons that have multiple sizes within one folder, such as multiple
 palette icon sizes, are differentiated by adding the icon size to the
@@ -1916,7 +1915,7 @@ suffix. For example, file_pal, file_pal24, file_pal32, where
 *_pal represents the default 16 x 16 pixel size and the *_pal24 and
 *_pal32 represent larger sizes of the same icon.
 
-==== Suggestions for File Naming Suffixes
+===== Suggestions for File Naming Suffixes
 
 image::images/name-conv-tabl.jpg[name-conv-tabl.jpg]
 
@@ -1939,7 +1938,7 @@ multiple sizes.
 TIP: [guideline2.16]*Guideline 2.16* +
 Keep the original file names provided.
 
-=== Folder Structure
+==== Folder Structure
 
 This section provides the Eclipse standard for folder names and
 structure for storing and implementing graphics within your plugin.
@@ -2001,7 +2000,7 @@ image::images/imp_folderstruct.png[imp_folderstruct]
 +
 image::images/imp_folderstruct_tabl.png[imp_folderstruct_tabl]
 
-==== Notes:
+===== Notes:
 
 1. For some legacy plug-ins, inside the *icons* folder, there is a
 folder called **full**, which then contains these icon type folders.


### PR DESCRIPTION
Have all the separate input documents be joined as a single page output document. If you ever used the JUnit 5 documentation, it looks exactly the same: https://junit.org/junit5/docs/current/user-guide/#overview

To do that, all headline levels needed to be increased by one (done via regex search/replace).

This does not change the structure of the files for editing, and it is still possible to generate separate pages of the input files (e.g. if needed for Eclipse Online help).

The build will now warn about invalid cross references for some of the guidelines, but those were also invalid before.

![grafik](https://user-images.githubusercontent.com/406876/209328446-ded317f8-f79d-4952-9e1b-6114eed32110.png)
