### PR TITLE
prohibit http links in documentation

### DIFF
--- a/component_dev.adoc
+++ b/component_dev.adoc
@@ -544,7 +544,7 @@ each object type in the editor. An command filter makes it easier for
 one plug-in to add an command to objects in an editor defined by another
 plug-in. The target is described using object type and attributes. For
 more information on the implementation of this concept, refer to
-http://www.eclipse.org/articles/viewArticle/ViewArticle2.html[Creating
+https://www.eclipse.org/articles/viewArticle/ViewArticle2.html[Creating
 an Eclipse View.]
 
 TIP: [guideline6.14]*Guideline 6.14* +
@@ -1043,7 +1043,7 @@ plug-in to add an command to objects in a view defined by another
 plug-in. The command target is described using object type and
 attributes. For more information on the implementation of this concept,
 refer to
-http://www.eclipse.org/articles/viewArticle/ViewArticle2.html[Creating
+https://www.eclipse.org/articles/viewArticle/ViewArticle2.html[Creating
 an Eclipse View.]
 
 TIP: [guideline7.17]*Guideline 7.17* +
@@ -1105,8 +1105,8 @@ object, there is no need to persist its state between sessions. Within
 the workbench, the state of the Navigator view, including the input and
 expansion state, is saved between sessions. For more information on the
 implementation of persistence, see
-"http://www.eclipse.org/articles/viewArticle/ViewArticle2.html[Creating
-an Eclipse View]".
+https://www.eclipse.org/articles/viewArticle/ViewArticle2.html[Creating
+an Eclipse View].
 
 TIP: [guideline7.20]*Guideline 7.20* +
 Persist the state of each view between sessions.
@@ -1219,7 +1219,7 @@ initial layout of views, and visibility of command sets within the
 perspective. You can also add your own actions or views to an existing
 perspective type. For more information on the implementation of these
 concepts, see
-http://www.eclipse.org/articles/using-perspectives/PerspectiveArticle.html[Using
+https://www.eclipse.org/articles/using-perspectives/PerspectiveArticle.html[Using
 Perspectives in the Eclipse UI].
 
 A new perspective type should be created when there is a group of

--- a/config/checkstyle-nohttp.xml
+++ b/config/checkstyle-nohttp.xml
@@ -1,0 +1,7 @@
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "https://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <property name="charset" value="UTF-8"/>
+    <property name="fileExtensions" value="adoc"/>
+    <module name="io.spring.nohttp.checkstyle.check.NoHttpCheck"/>
+</module>

--- a/general_ui_guidelines.adoc
+++ b/general_ui_guidelines.adoc
@@ -74,7 +74,7 @@ useful, join the Eclipse community, write a proposal, and work with the
 Eclipse community to make Eclipse a better platform for product
 development and increase customer satisfaction.
 
-Visit http://www.eclipse.org/[www.eclipse.org] and join the 
+Visit https://www.eclipse.org/[www.eclipse.org] and join the 
 mailto:ui-best-practices-working-group@eclipse.org[Eclipse UI mailing list]. 
 
 TIP: [guideline1.4]*Guideline 1.4* +

--- a/index.adoc
+++ b/index.adoc
@@ -1,29 +1,21 @@
-= Eclipse UI Guidelines
+= Eclipse UI Guidelines ({version})
+
 include::_settings.adoc[]
 :toc: left
 
-UI Best Practices Working Group
-{version}
-
-__' This document is a working draft. Version 2.1 is the base with 3.x
-updates indicated with "(3.x update)".__'
+_This document is a working draft. Version 2.1 is the base with 3.x
+updates indicated with "(3.x update)"._
 
 *Nick Edgar, Kevin Haaland, Jin Li and Kimberley Peter, with
 contributions from members of the
-link:http://wiki.eclipse.org/User_Interface_Best_Practices_Working_Group[User Interface Best
-Practices Working Group]*
+link:https://wiki.eclipse.org/User_Interface_Best_Practices_Working_Group[User Interface Best
+Practices Working Group]*.
 
-*Last major revision: November 2007* +
-*Convertion into Asciidoc: September 2016*
-
-NOTE: Please use the
-https://github.com/eclipse-platform/ui-best-practices/discussions[discussion
-page] to add comments instead of embedding them in this document.
-
-:toc:
+*Last major revision: November 2007*
 
 
-== Notice
+== How to contribute to this document
+
 Your feedback can influence the ideas and guidelines described here. If
 you have suggestions, please provide us with your feedback on the
 mailto:platform-ui-dev@eclipse.org?subject=UI%20Guidelines%20v2.1%20Feedback[UI
@@ -31,8 +23,13 @@ mailing list] or on the
 https://github.com/eclipse-platform/ui-best-practices/discussions[discussion
 page].
 
+NOTE: Please use the
+https://github.com/eclipse-platform/ui-best-practices/discussions[discussion
+page] to add comments instead of embedding them in this document.
+
 
 == UI Checklist
+
 The xref:top_ten_lists.adoc[Top Ten Lists] is a shortlist of the most relevant
 and easy to apply Eclipse **User Interface Guidelines**. 
 Start by using xref:top_ten_lists.adoc[this list], referring to the linked guideline items for details, 
@@ -40,7 +37,9 @@ then use the xref:eclipse_ui_full_checklist.adoc[Full Checklist] for additional 
 For comments please use the 
 https://github.com/eclipse-platform/ui-best-practices/issues[UI Best Practices GitHub Issues].
 
+
 == Introduction
+
 In this document the Eclipse user interface guidelines are defined.
 
 Eclipse is a universal tool platform - an open, extensible IDE for

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,32 @@
 					</logHandler>
 				</configuration>
 			</plugin>
+			<!-- verify that AsciiDoc files contain only https urls -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.2.0</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.spring.nohttp</groupId>
+                        <artifactId>nohttp-checkstyle</artifactId>
+                        <version>0.0.10</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <configLocation>config/checkstyle-nohttp.xml</configLocation>
+                    <includes>**/*</includes>
+                    <excludes>.git/**/*,target/**/*</excludes>
+                    <sourceDirectories>./</sourceDirectories>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 		</plugins>
 	</build>
 </project>

--- a/standard_components.adoc
+++ b/standard_components.adoc
@@ -51,7 +51,7 @@ apply a project nature to the managed resources, and use the project
 nature attribute in all context menu contributions.
 
 For more information on command filtering, refer to
-http://www.eclipse.org/articles/viewArticle/ViewArticle2.html[Creating
+https://www.eclipse.org/articles/viewArticle/ViewArticle2.html[Creating
 an Eclipse View]. The standard attributes for resources are defined in
 IResourceActionFilter.java (see below).
 
@@ -144,7 +144,7 @@ in the Tasks view is a __marker__, a general mechanism for associate
 notes with a resource. Use the attributes within
 IMarkerActionFilter.java to control the visibility of Task object
 actions (see below). For more information on command filtering, refer to
-http://www.eclipse.org/articles/viewArticle/ViewArticle2.html[Creating
+https://www.eclipse.org/articles/viewArticle/ViewArticle2.html[Creating
 an Eclipse View].
 
 [source,java]

--- a/ui_graphics.adoc
+++ b/ui_graphics.adoc
@@ -5,7 +5,7 @@
 The following guide covers user interface (UI) graphics for Eclipse-based tools. 
 All visual user interface elements created for Eclipse-based tools follow a 
 common style called the *_Eclipse visual style_* or **_Eclipse style_**. Any 
-product, tool, or plug-in based on the http://www.eclipse.org[Eclipse] Workbench
+product, tool, or plug-in based on the https://www.eclipse.org[Eclipse] Workbench
 should follow these guidelines to help ensure consistency of visual user 
 interface elements. Consistency includes visual style, meaning, and 
 implementation conventions.
@@ -384,11 +384,11 @@ In The GIMP, simply Save As PNG.
 +
 Related Information::
   This information replaces that provided in the 
-  http://www.eclipse.org/articles/Article-UI-Guidelines/Index.html[Eclipse UI 
+  https://www.eclipse.org/articles/Article-UI-Guidelines/Index.html[Eclipse UI 
   Guidelines, Version 2.1], in the section titled “Visual Design – Icon 
   Palettes” (Guidelines 2.2-2.4):
 + 
-The GIMP User Manual is available online at: http://www.gimp.org/docs/
+The GIMP User Manual is available online at: https://www.gimp.org/docs/
 
 ===== Wizard Banner Graphics
 
@@ -930,7 +930,7 @@ PNG is a bitmapped image format that employs lossless data compression.
 PNG was created to improve upon and replace the GIF format, as an
 image-file format not requiring a patent license. PNG is pronounced
 "ping" (/pɪŋ/ in IPA), but can be spoken "P-N-G" (as described at
-http://en.wikipedia.org/wiki/PNG). One of the great values of PNG format
+https://en.wikipedia.org/wiki/PNG). One of the great values of PNG format
 is its support for alphas or transparency, allowing bleed through of the
 background on which these graphics sit.
 


### PR DESCRIPTION
Use checkstyle with an extension to verify that all links use https.