### PR TITLE
Encourage the "one sentence per line" rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,18 +49,11 @@ Please refere to
 [AsciiDoc Syntax Quick Reference](http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/).
 
 ### Making changes
-Ensure that lines in `.adoc` files are *hard wrapped* at 80 columns. This makes it
-much easier to view the diffs in git. How you do this depends on your particular
-text editor.
 
-As a sanity check, please install the Git hooks contained in this repository
-by running `bin/git/install-hooks`. The pre-commit hook script will run 
-automatically before you make a commit and warn you if you have lines longer 
-than 80 characters.
+Ensure that every sentence is in one line.
+This is the so-called _One sentence per line_ best practice from Asciidoc, see https://asciidoctor.org/docs/asciidoc-recommended-practices/#one-sentence-per-line for details. 
 
-Sometimes, it is *not* possible to break at 80 columns, e.g., because you have a
-URL that cannot be split across lines. In that case, you can use `git commit
---no-verify` to temporarily bypass the check.
+
 
 ### Update Process
 Please submit pull requests for any proposals/semantic changes/enhancements.


### PR DESCRIPTION
Don’t wrap text at a fixed column width. Instead, put each sentence on its own line, a technique called sentence per line. This technique is similar to how you write and organize source code. The result can be spectacular.

Here are some of the advantages of using the sentence per line style:

It prevents reflows (meaning a change early in the paragraph won’t cause the remaining lines in the paragraph to reposition).

You can easily swap sentences.

You can easily separate or join paragraphs.

You can comment out sentences or add commentary to them.

You can spot sentences which are too long or sentences that vary widely in length.

You can spot redundant (and thus mundane) patterns in your writing.

We picked up this idea from the writing guide in the Neo4j documentation. However, it seems like the idea dates back a discovery by Buckminster Fuller in the 1930s, who called it ventilated prose. The technique was also recommended in 2009 by Brandon Rhodes in a blog post about Semantic Linefeeds.

It’s important to note that this technique works because AsciiDoc doesn’t treat wrapped lines in prose as hard line breaks. At least, it doesn’t show up that way to the reader. The line breaks between contiguous lines of prose will not be visible in the rendered document (i.e., as the reader sees it).

See https://asciidoctor.org/docs/asciidoc-recommended-practices/#one-sentence-per-line For #41