### PR TITLE
GIF is no longer used

### DIFF
--- a/ui_graphics.adoc
+++ b/ui_graphics.adoc
@@ -375,10 +375,7 @@ The
 +
 Save your images with the palette as a base
 +
-In Adobe Photoshop, when an image is complete and ready to be saved to
-  GIF, index the image to "exact" color. This indexing preserves all of
-  the colors the graphic was created with, including any colors you have
-  added that are not contained in the base palette.
+In Adobe Photoshop, when an image is complete and ready to be saved to PNG, index the image to "exact" color. This indexing preserves all of the colors the graphic was created with, including any colors you have added that are not contained in the base palette.
 +
 In The GIMP, simply Save As PNG.
 +
@@ -547,16 +544,6 @@ The background for wizard banners is part of the final graphic. It is
   a light blue curvilinear element that does not vary. However, the
   background color of the banner area does vary from one operation
   system and theme to another.
-+
-Previous to Eclipse 3.3, all wizard banner graphics were in GIF
-  format, which meant that the blue curvilinear element blended to a
-  white background that was part of the final cut image. This worked
-  well on standard Windows and OSX themes that have a white banner
-  background, but not on Linux flavors that have a grey banner
-  background. Fortunately, Eclipse now supports the PNG graphic format
-  and all Eclipse Project (SDK) wizard banner graphics have been
-  converted to PNG so that graphic blends to whatever background color
-  it sits on.
 
 TIP: [[guideline2.1]]*Guideline 2.1 (3.x update)* +
 Follow the visual style established for Eclipse UI graphics.
@@ -909,7 +896,7 @@ different graphic types.
 
 ===== GIF - Graphics Interchange Format
 
-GIF images should not be used as they can look bad on the selected theme of the Eclipse IDE.
+GIF images should not be used. The cannot handle transparency very well and because of this they can look bad on the selected theme of the Eclipse IDE.
 Prefer the usage of PNG files.
 
 ===== PNG - Portable Network Graphics


### PR DESCRIPTION
We should not longer use GIF files. Remove unneeded references to that file format.