### PR TITLE
Add Icon expandall.svg & collapseall.svg

### DIFF
--- a/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.core.tools.resources/collapseall.svg
+++ b/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.core.tools.resources/collapseall.svg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   fill="none"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="collapseall.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   inkscape:export-filename="collapseall_16x16.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#545454"
+     inkscape:zoom="24.84375"
+     inkscape:cx="10.566038"
+     inkscape:cy="9.1974843"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <rect
+     x="3.5"
+     y="7"
+     width="9"
+     height="2"
+     rx="1"
+     fill="#a8a8a8"
+     id="rect5"
+     clip-path="none" />
+  <defs
+     id="defs6">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7">
+      <g
+         id="g8">
+        <rect
+           width="16"
+           height="16"
+           fill="#ffffff"
+           id="rect8"
+           x="0"
+           y="0" />
+      </g>
+    </clipPath>
+  </defs>
+  <rect
+     style="fill:none;stroke:#a8a8a8;stroke-width:2;stroke-linecap:round;stroke-dasharray:none;paint-order:markers stroke fill;stroke-opacity:1"
+     id="rect1"
+     width="14"
+     height="14"
+     x="1"
+     y="1"
+     rx="1"
+     ry="1" />
+</svg>

--- a/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.core.tools/collapseall.svg
+++ b/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.core.tools/collapseall.svg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   fill="none"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="collapseall.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   inkscape:export-filename="collapseall_16x16.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#545454"
+     inkscape:zoom="24.84375"
+     inkscape:cx="10.566038"
+     inkscape:cy="9.1974843"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <rect
+     x="3.5"
+     y="7"
+     width="9"
+     height="2"
+     rx="1"
+     fill="#a8a8a8"
+     id="rect5"
+     clip-path="none" />
+  <defs
+     id="defs6">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7">
+      <g
+         id="g8">
+        <rect
+           width="16"
+           height="16"
+           fill="#ffffff"
+           id="rect8"
+           x="0"
+           y="0" />
+      </g>
+    </clipPath>
+  </defs>
+  <rect
+     style="fill:none;stroke:#a8a8a8;stroke-width:2;stroke-linecap:round;stroke-dasharray:none;paint-order:markers stroke fill;stroke-opacity:1"
+     id="rect1"
+     width="14"
+     height="14"
+     x="1"
+     y="1"
+     rx="1"
+     ry="1" />
+</svg>

--- a/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.debug.ui/elcl16/expandall.svg
+++ b/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.debug.ui/elcl16/expandall.svg
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   version="1.1"
+   xml:space="preserve"
+   style="fill-rule:evenodd;clip-rule:evenodd;stroke-linecap:round;"
+   id="svg1"
+   sodipodi:docname="expandall.svg"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:serif="http://www.serif.com/"><defs
+   id="defs1" /><sodipodi:namedview
+   id="namedview1"
+   pagecolor="#ffffff"
+   bordercolor="#000000"
+   borderopacity="0.25"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   inkscape:zoom="48.3125"
+   inkscape:cx="7.9896507"
+   inkscape:cy="8"
+   inkscape:window-width="1920"
+   inkscape:window-height="991"
+   inkscape:window-x="-9"
+   inkscape:window-y="-9"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="svg1" />
+    <path
+   id="rect5"
+   d="M12.5,8C12.5,8.552 12.052,9 11.5,9L4.5,9C3.948,9 3.5,8.552 3.5,8C3.5,7.448 3.948,7 4.5,7L11.5,7C12.052,7 12.5,7.448 12.5,8Z"
+   style="fill:rgb(168,168,168);" />
+    <g
+   id="rect51"
+   serif:id="rect5"
+   transform="matrix(0,1,-1,0,16,-0)">
+        <path
+   d="M12.5,8C12.5,8.552 12.052,9 11.5,9L4.5,9C3.948,9 3.5,8.552 3.5,8C3.5,7.448 3.948,7 4.5,7L11.5,7C12.052,7 12.5,7.448 12.5,8Z"
+   style="fill:rgb(168,168,168);"
+   id="path1" />
+    </g>
+    <path
+   id="rect1"
+   d="M15,2L15,14C15,14.552 14.552,15 14,15L2,15C1.448,15 1,14.552 1,14L1,2C1,1.448 1.448,1 2,1L14,1C14.552,1 15,1.448 15,2Z"
+   style="fill:none;stroke:rgb(168,168,168);stroke-width:2px;" />
+</svg>

--- a/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.e4.tools.context.spy/collapseall.svg
+++ b/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.e4.tools.context.spy/collapseall.svg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   fill="none"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="collapseall.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   inkscape:export-filename="collapseall_16x16.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#545454"
+     inkscape:zoom="24.84375"
+     inkscape:cx="10.566038"
+     inkscape:cy="9.1974843"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <rect
+     x="3.5"
+     y="7"
+     width="9"
+     height="2"
+     rx="1"
+     fill="#a8a8a8"
+     id="rect5"
+     clip-path="none" />
+  <defs
+     id="defs6">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7">
+      <g
+         id="g8">
+        <rect
+           width="16"
+           height="16"
+           fill="#ffffff"
+           id="rect8"
+           x="0"
+           y="0" />
+      </g>
+    </clipPath>
+  </defs>
+  <rect
+     style="fill:none;stroke:#a8a8a8;stroke-width:2;stroke-linecap:round;stroke-dasharray:none;paint-order:markers stroke fill;stroke-opacity:1"
+     id="rect1"
+     width="14"
+     height="14"
+     x="1"
+     y="1"
+     rx="1"
+     ry="1" />
+</svg>

--- a/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.e4.tools.context.spy/expandall.svg
+++ b/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.e4.tools.context.spy/expandall.svg
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   version="1.1"
+   xml:space="preserve"
+   style="fill-rule:evenodd;clip-rule:evenodd;stroke-linecap:round;"
+   id="svg1"
+   sodipodi:docname="expandall.svg"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:serif="http://www.serif.com/"><defs
+   id="defs1" /><sodipodi:namedview
+   id="namedview1"
+   pagecolor="#ffffff"
+   bordercolor="#000000"
+   borderopacity="0.25"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   inkscape:zoom="48.3125"
+   inkscape:cx="7.9896507"
+   inkscape:cy="8"
+   inkscape:window-width="1920"
+   inkscape:window-height="991"
+   inkscape:window-x="-9"
+   inkscape:window-y="-9"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="svg1" />
+    <path
+   id="rect5"
+   d="M12.5,8C12.5,8.552 12.052,9 11.5,9L4.5,9C3.948,9 3.5,8.552 3.5,8C3.5,7.448 3.948,7 4.5,7L11.5,7C12.052,7 12.5,7.448 12.5,8Z"
+   style="fill:rgb(168,168,168);" />
+    <g
+   id="rect51"
+   serif:id="rect5"
+   transform="matrix(0,1,-1,0,16,-0)">
+        <path
+   d="M12.5,8C12.5,8.552 12.052,9 11.5,9L4.5,9C3.948,9 3.5,8.552 3.5,8C3.5,7.448 3.948,7 4.5,7L11.5,7C12.052,7 12.5,7.448 12.5,8Z"
+   style="fill:rgb(168,168,168);"
+   id="path1" />
+    </g>
+    <path
+   id="rect1"
+   d="M15,2L15,14C15,14.552 14.552,15 14,15L2,15C1.448,15 1,14.552 1,14L1,2C1,1.448 1.448,1 2,1L14,1C14.552,1 15,1.448 15,2Z"
+   style="fill:none;stroke:rgb(168,168,168);stroke-width:2px;" />
+</svg>

--- a/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.help.ui/elcl16/collapseall.svg
+++ b/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.help.ui/elcl16/collapseall.svg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   fill="none"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="collapseall.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   inkscape:export-filename="collapseall_16x16.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#545454"
+     inkscape:zoom="24.84375"
+     inkscape:cx="10.566038"
+     inkscape:cy="9.1974843"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <rect
+     x="3.5"
+     y="7"
+     width="9"
+     height="2"
+     rx="1"
+     fill="#a8a8a8"
+     id="rect5"
+     clip-path="none" />
+  <defs
+     id="defs6">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7">
+      <g
+         id="g8">
+        <rect
+           width="16"
+           height="16"
+           fill="#ffffff"
+           id="rect8"
+           x="0"
+           y="0" />
+      </g>
+    </clipPath>
+  </defs>
+  <rect
+     style="fill:none;stroke:#a8a8a8;stroke-width:2;stroke-linecap:round;stroke-dasharray:none;paint-order:markers stroke fill;stroke-opacity:1"
+     id="rect1"
+     width="14"
+     height="14"
+     x="1"
+     y="1"
+     rx="1"
+     ry="1" />
+</svg>

--- a/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.jdt.astview/e/collapseall.svg
+++ b/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.jdt.astview/e/collapseall.svg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   fill="none"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="collapseall.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   inkscape:export-filename="collapseall_16x16.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#545454"
+     inkscape:zoom="24.84375"
+     inkscape:cx="10.566038"
+     inkscape:cy="9.1974843"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <rect
+     x="3.5"
+     y="7"
+     width="9"
+     height="2"
+     rx="1"
+     fill="#a8a8a8"
+     id="rect5"
+     clip-path="none" />
+  <defs
+     id="defs6">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7">
+      <g
+         id="g8">
+        <rect
+           width="16"
+           height="16"
+           fill="#ffffff"
+           id="rect8"
+           x="0"
+           y="0" />
+      </g>
+    </clipPath>
+  </defs>
+  <rect
+     style="fill:none;stroke:#a8a8a8;stroke-width:2;stroke-linecap:round;stroke-dasharray:none;paint-order:markers stroke fill;stroke-opacity:1"
+     id="rect1"
+     width="14"
+     height="14"
+     x="1"
+     y="1"
+     rx="1"
+     ry="1" />
+</svg>

--- a/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.jdt.astview/e/expandall.svg
+++ b/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.jdt.astview/e/expandall.svg
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   version="1.1"
+   xml:space="preserve"
+   style="fill-rule:evenodd;clip-rule:evenodd;stroke-linecap:round;"
+   id="svg1"
+   sodipodi:docname="expandall.svg"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:serif="http://www.serif.com/"><defs
+   id="defs1" /><sodipodi:namedview
+   id="namedview1"
+   pagecolor="#ffffff"
+   bordercolor="#000000"
+   borderopacity="0.25"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   inkscape:zoom="48.3125"
+   inkscape:cx="7.9896507"
+   inkscape:cy="8"
+   inkscape:window-width="1920"
+   inkscape:window-height="991"
+   inkscape:window-x="-9"
+   inkscape:window-y="-9"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="svg1" />
+    <path
+   id="rect5"
+   d="M12.5,8C12.5,8.552 12.052,9 11.5,9L4.5,9C3.948,9 3.5,8.552 3.5,8C3.5,7.448 3.948,7 4.5,7L11.5,7C12.052,7 12.5,7.448 12.5,8Z"
+   style="fill:rgb(168,168,168);" />
+    <g
+   id="rect51"
+   serif:id="rect5"
+   transform="matrix(0,1,-1,0,16,-0)">
+        <path
+   d="M12.5,8C12.5,8.552 12.052,9 11.5,9L4.5,9C3.948,9 3.5,8.552 3.5,8C3.5,7.448 3.948,7 4.5,7L11.5,7C12.052,7 12.5,7.448 12.5,8Z"
+   style="fill:rgb(168,168,168);"
+   id="path1" />
+    </g>
+    <path
+   id="rect1"
+   d="M15,2L15,14C15,14.552 14.552,15 14,15L2,15C1.448,15 1,14.552 1,14L1,2C1,1.448 1.448,1 2,1L14,1C14.552,1 15,1.448 15,2Z"
+   style="fill:none;stroke:rgb(168,168,168);stroke-width:2px;" />
+</svg>

--- a/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.jdt.ui/elcl16/collapseall.svg
+++ b/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.jdt.ui/elcl16/collapseall.svg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   fill="none"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="collapseall.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   inkscape:export-filename="collapseall_16x16.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#545454"
+     inkscape:zoom="24.84375"
+     inkscape:cx="10.566038"
+     inkscape:cy="9.1974843"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <rect
+     x="3.5"
+     y="7"
+     width="9"
+     height="2"
+     rx="1"
+     fill="#a8a8a8"
+     id="rect5"
+     clip-path="none" />
+  <defs
+     id="defs6">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7">
+      <g
+         id="g8">
+        <rect
+           width="16"
+           height="16"
+           fill="#ffffff"
+           id="rect8"
+           x="0"
+           y="0" />
+      </g>
+    </clipPath>
+  </defs>
+  <rect
+     style="fill:none;stroke:#a8a8a8;stroke-width:2;stroke-linecap:round;stroke-dasharray:none;paint-order:markers stroke fill;stroke-opacity:1"
+     id="rect1"
+     width="14"
+     height="14"
+     x="1"
+     y="1"
+     rx="1"
+     ry="1" />
+</svg>

--- a/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.mylyn.wikitext.ui/collapseall.svg
+++ b/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.mylyn.wikitext.ui/collapseall.svg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   fill="none"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="collapseall.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   inkscape:export-filename="collapseall_16x16.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#545454"
+     inkscape:zoom="24.84375"
+     inkscape:cx="10.566038"
+     inkscape:cy="9.1974843"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <rect
+     x="3.5"
+     y="7"
+     width="9"
+     height="2"
+     rx="1"
+     fill="#a8a8a8"
+     id="rect5"
+     clip-path="none" />
+  <defs
+     id="defs6">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7">
+      <g
+         id="g8">
+        <rect
+           width="16"
+           height="16"
+           fill="#ffffff"
+           id="rect8"
+           x="0"
+           y="0" />
+      </g>
+    </clipPath>
+  </defs>
+  <rect
+     style="fill:none;stroke:#a8a8a8;stroke-width:2;stroke-linecap:round;stroke-dasharray:none;paint-order:markers stroke fill;stroke-opacity:1"
+     id="rect1"
+     width="14"
+     height="14"
+     x="1"
+     y="1"
+     rx="1"
+     ry="1" />
+</svg>

--- a/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.pde.runtime/elcl16/collapseall.svg
+++ b/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.pde.runtime/elcl16/collapseall.svg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   fill="none"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="collapseall.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   inkscape:export-filename="collapseall_16x16.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#545454"
+     inkscape:zoom="24.84375"
+     inkscape:cx="10.566038"
+     inkscape:cy="9.1974843"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <rect
+     x="3.5"
+     y="7"
+     width="9"
+     height="2"
+     rx="1"
+     fill="#a8a8a8"
+     id="rect5"
+     clip-path="none" />
+  <defs
+     id="defs6">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7">
+      <g
+         id="g8">
+        <rect
+           width="16"
+           height="16"
+           fill="#ffffff"
+           id="rect8"
+           x="0"
+           y="0" />
+      </g>
+    </clipPath>
+  </defs>
+  <rect
+     style="fill:none;stroke:#a8a8a8;stroke-width:2;stroke-linecap:round;stroke-dasharray:none;paint-order:markers stroke fill;stroke-opacity:1"
+     id="rect1"
+     width="14"
+     height="14"
+     x="1"
+     y="1"
+     rx="1"
+     ry="1" />
+</svg>

--- a/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.pde.ui/elcl16/collapseall.svg
+++ b/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.pde.ui/elcl16/collapseall.svg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   fill="none"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="collapseall.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   inkscape:export-filename="collapseall_16x16.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#545454"
+     inkscape:zoom="24.84375"
+     inkscape:cx="10.566038"
+     inkscape:cy="9.1974843"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <rect
+     x="3.5"
+     y="7"
+     width="9"
+     height="2"
+     rx="1"
+     fill="#a8a8a8"
+     id="rect5"
+     clip-path="none" />
+  <defs
+     id="defs6">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7">
+      <g
+         id="g8">
+        <rect
+           width="16"
+           height="16"
+           fill="#ffffff"
+           id="rect8"
+           x="0"
+           y="0" />
+      </g>
+    </clipPath>
+  </defs>
+  <rect
+     style="fill:none;stroke:#a8a8a8;stroke-width:2;stroke-linecap:round;stroke-dasharray:none;paint-order:markers stroke fill;stroke-opacity:1"
+     id="rect1"
+     width="14"
+     height="14"
+     x="1"
+     y="1"
+     rx="1"
+     ry="1" />
+</svg>

--- a/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.search/elcl16/collapseall.svg
+++ b/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.search/elcl16/collapseall.svg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   fill="none"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="collapseall.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   inkscape:export-filename="collapseall_16x16.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#545454"
+     inkscape:zoom="24.84375"
+     inkscape:cx="10.566038"
+     inkscape:cy="9.1974843"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <rect
+     x="3.5"
+     y="7"
+     width="9"
+     height="2"
+     rx="1"
+     fill="#a8a8a8"
+     id="rect5"
+     clip-path="none" />
+  <defs
+     id="defs6">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7">
+      <g
+         id="g8">
+        <rect
+           width="16"
+           height="16"
+           fill="#ffffff"
+           id="rect8"
+           x="0"
+           y="0" />
+      </g>
+    </clipPath>
+  </defs>
+  <rect
+     style="fill:none;stroke:#a8a8a8;stroke-width:2;stroke-linecap:round;stroke-dasharray:none;paint-order:markers stroke fill;stroke-opacity:1"
+     id="rect1"
+     width="14"
+     height="14"
+     x="1"
+     y="1"
+     rx="1"
+     ry="1" />
+</svg>

--- a/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.search/elcl16/expandall.svg
+++ b/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.search/elcl16/expandall.svg
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   version="1.1"
+   xml:space="preserve"
+   style="fill-rule:evenodd;clip-rule:evenodd;stroke-linecap:round;"
+   id="svg1"
+   sodipodi:docname="expandall.svg"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:serif="http://www.serif.com/"><defs
+   id="defs1" /><sodipodi:namedview
+   id="namedview1"
+   pagecolor="#ffffff"
+   bordercolor="#000000"
+   borderopacity="0.25"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   inkscape:zoom="48.3125"
+   inkscape:cx="7.9896507"
+   inkscape:cy="8"
+   inkscape:window-width="1920"
+   inkscape:window-height="991"
+   inkscape:window-x="-9"
+   inkscape:window-y="-9"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="svg1" />
+    <path
+   id="rect5"
+   d="M12.5,8C12.5,8.552 12.052,9 11.5,9L4.5,9C3.948,9 3.5,8.552 3.5,8C3.5,7.448 3.948,7 4.5,7L11.5,7C12.052,7 12.5,7.448 12.5,8Z"
+   style="fill:rgb(168,168,168);" />
+    <g
+   id="rect51"
+   serif:id="rect5"
+   transform="matrix(0,1,-1,0,16,-0)">
+        <path
+   d="M12.5,8C12.5,8.552 12.052,9 11.5,9L4.5,9C3.948,9 3.5,8.552 3.5,8C3.5,7.448 3.948,7 4.5,7L11.5,7C12.052,7 12.5,7.448 12.5,8Z"
+   style="fill:rgb(168,168,168);"
+   id="path1" />
+    </g>
+    <path
+   id="rect1"
+   d="M15,2L15,14C15,14.552 14.552,15 14,15L2,15C1.448,15 1,14.552 1,14L1,2C1,1.448 1.448,1 2,1L14,1C14.552,1 15,1.448 15,2Z"
+   style="fill:none;stroke:rgb(168,168,168);stroke-width:2px;" />
+</svg>

--- a/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.team.cvs.ui/elcl16/collapseall.svg
+++ b/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.team.cvs.ui/elcl16/collapseall.svg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   fill="none"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="collapseall.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   inkscape:export-filename="collapseall_16x16.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#545454"
+     inkscape:zoom="24.84375"
+     inkscape:cx="10.566038"
+     inkscape:cy="9.1974843"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <rect
+     x="3.5"
+     y="7"
+     width="9"
+     height="2"
+     rx="1"
+     fill="#a8a8a8"
+     id="rect5"
+     clip-path="none" />
+  <defs
+     id="defs6">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7">
+      <g
+         id="g8">
+        <rect
+           width="16"
+           height="16"
+           fill="#ffffff"
+           id="rect8"
+           x="0"
+           y="0" />
+      </g>
+    </clipPath>
+  </defs>
+  <rect
+     style="fill:none;stroke:#a8a8a8;stroke-width:2;stroke-linecap:round;stroke-dasharray:none;paint-order:markers stroke fill;stroke-opacity:1"
+     id="rect1"
+     width="14"
+     height="14"
+     x="1"
+     y="1"
+     rx="1"
+     ry="1" />
+</svg>

--- a/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.team.ui/elcl16/collapseall.svg
+++ b/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.team.ui/elcl16/collapseall.svg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   fill="none"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="collapseall.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   inkscape:export-filename="collapseall_16x16.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#545454"
+     inkscape:zoom="24.84375"
+     inkscape:cx="10.566038"
+     inkscape:cy="9.1974843"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <rect
+     x="3.5"
+     y="7"
+     width="9"
+     height="2"
+     rx="1"
+     fill="#a8a8a8"
+     id="rect5"
+     clip-path="none" />
+  <defs
+     id="defs6">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7">
+      <g
+         id="g8">
+        <rect
+           width="16"
+           height="16"
+           fill="#ffffff"
+           id="rect8"
+           x="0"
+           y="0" />
+      </g>
+    </clipPath>
+  </defs>
+  <rect
+     style="fill:none;stroke:#a8a8a8;stroke-width:2;stroke-linecap:round;stroke-dasharray:none;paint-order:markers stroke fill;stroke-opacity:1"
+     id="rect1"
+     width="14"
+     height="14"
+     x="1"
+     y="1"
+     rx="1"
+     ry="1" />
+</svg>

--- a/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.ui.cheatsheets/elcl16/collapseall.svg
+++ b/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.ui.cheatsheets/elcl16/collapseall.svg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   fill="none"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="collapseall.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   inkscape:export-filename="collapseall_16x16.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#545454"
+     inkscape:zoom="24.84375"
+     inkscape:cx="10.566038"
+     inkscape:cy="9.1974843"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <rect
+     x="3.5"
+     y="7"
+     width="9"
+     height="2"
+     rx="1"
+     fill="#a8a8a8"
+     id="rect5"
+     clip-path="none" />
+  <defs
+     id="defs6">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7">
+      <g
+         id="g8">
+        <rect
+           width="16"
+           height="16"
+           fill="#ffffff"
+           id="rect8"
+           x="0"
+           y="0" />
+      </g>
+    </clipPath>
+  </defs>
+  <rect
+     style="fill:none;stroke:#a8a8a8;stroke-width:2;stroke-linecap:round;stroke-dasharray:none;paint-order:markers stroke fill;stroke-opacity:1"
+     id="rect1"
+     width="14"
+     height="14"
+     x="1"
+     y="1"
+     rx="1"
+     ry="1" />
+</svg>

--- a/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.ui.ide/elcl16/collapseall.svg
+++ b/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.ui.ide/elcl16/collapseall.svg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   fill="none"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="collapseall.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   inkscape:export-filename="collapseall_16x16.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#545454"
+     inkscape:zoom="24.84375"
+     inkscape:cx="10.566038"
+     inkscape:cy="9.1974843"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <rect
+     x="3.5"
+     y="7"
+     width="9"
+     height="2"
+     rx="1"
+     fill="#a8a8a8"
+     id="rect5"
+     clip-path="none" />
+  <defs
+     id="defs6">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7">
+      <g
+         id="g8">
+        <rect
+           width="16"
+           height="16"
+           fill="#ffffff"
+           id="rect8"
+           x="0"
+           y="0" />
+      </g>
+    </clipPath>
+  </defs>
+  <rect
+     style="fill:none;stroke:#a8a8a8;stroke-width:2;stroke-linecap:round;stroke-dasharray:none;paint-order:markers stroke fill;stroke-opacity:1"
+     id="rect1"
+     width="14"
+     height="14"
+     x="1"
+     y="1"
+     rx="1"
+     ry="1" />
+</svg>

--- a/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.ui.navigator.resources/elcl16/collapseall.svg
+++ b/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.ui.navigator.resources/elcl16/collapseall.svg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   fill="none"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="collapseall.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   inkscape:export-filename="collapseall_16x16.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#545454"
+     inkscape:zoom="24.84375"
+     inkscape:cx="10.566038"
+     inkscape:cy="9.1974843"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <rect
+     x="3.5"
+     y="7"
+     width="9"
+     height="2"
+     rx="1"
+     fill="#a8a8a8"
+     id="rect5"
+     clip-path="none" />
+  <defs
+     id="defs6">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7">
+      <g
+         id="g8">
+        <rect
+           width="16"
+           height="16"
+           fill="#ffffff"
+           id="rect8"
+           x="0"
+           y="0" />
+      </g>
+    </clipPath>
+  </defs>
+  <rect
+     style="fill:none;stroke:#a8a8a8;stroke-width:2;stroke-linecap:round;stroke-dasharray:none;paint-order:markers stroke fill;stroke-opacity:1"
+     id="rect1"
+     width="14"
+     height="14"
+     x="1"
+     y="1"
+     rx="1"
+     ry="1" />
+</svg>

--- a/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.ui.navigator/elcl16/collapseall.svg
+++ b/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.ui.navigator/elcl16/collapseall.svg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   fill="none"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="collapseall.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   inkscape:export-filename="collapseall_16x16.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#545454"
+     inkscape:zoom="24.84375"
+     inkscape:cx="10.566038"
+     inkscape:cy="9.1974843"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <rect
+     x="3.5"
+     y="7"
+     width="9"
+     height="2"
+     rx="1"
+     fill="#a8a8a8"
+     id="rect5"
+     clip-path="none" />
+  <defs
+     id="defs6">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7">
+      <g
+         id="g8">
+        <rect
+           width="16"
+           height="16"
+           fill="#ffffff"
+           id="rect8"
+           x="0"
+           y="0" />
+      </g>
+    </clipPath>
+  </defs>
+  <rect
+     style="fill:none;stroke:#a8a8a8;stroke-width:2;stroke-linecap:round;stroke-dasharray:none;paint-order:markers stroke fill;stroke-opacity:1"
+     id="rect1"
+     width="14"
+     height="14"
+     x="1"
+     y="1"
+     rx="1"
+     ry="1" />
+</svg>

--- a/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.ui.views.log/elcl16/collapseall.svg
+++ b/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.ui.views.log/elcl16/collapseall.svg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   fill="none"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="collapseall.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   inkscape:export-filename="collapseall_16x16.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#545454"
+     inkscape:zoom="24.84375"
+     inkscape:cx="10.566038"
+     inkscape:cy="9.1974843"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <rect
+     x="3.5"
+     y="7"
+     width="9"
+     height="2"
+     rx="1"
+     fill="#a8a8a8"
+     id="rect5"
+     clip-path="none" />
+  <defs
+     id="defs6">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7">
+      <g
+         id="g8">
+        <rect
+           width="16"
+           height="16"
+           fill="#ffffff"
+           id="rect8"
+           x="0"
+           y="0" />
+      </g>
+    </clipPath>
+  </defs>
+  <rect
+     style="fill:none;stroke:#a8a8a8;stroke-width:2;stroke-linecap:round;stroke-dasharray:none;paint-order:markers stroke fill;stroke-opacity:1"
+     id="rect1"
+     width="14"
+     height="14"
+     x="1"
+     y="1"
+     rx="1"
+     ry="1" />
+</svg>

--- a/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.ui.workbench.texteditor/elcl16/collapseall.svg
+++ b/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.ui.workbench.texteditor/elcl16/collapseall.svg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   fill="none"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="collapseall.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   inkscape:export-filename="collapseall_16x16.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#545454"
+     inkscape:zoom="24.84375"
+     inkscape:cx="10.566038"
+     inkscape:cy="9.1974843"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <rect
+     x="3.5"
+     y="7"
+     width="9"
+     height="2"
+     rx="1"
+     fill="#a8a8a8"
+     id="rect5"
+     clip-path="none" />
+  <defs
+     id="defs6">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7">
+      <g
+         id="g8">
+        <rect
+           width="16"
+           height="16"
+           fill="#ffffff"
+           id="rect8"
+           x="0"
+           y="0" />
+      </g>
+    </clipPath>
+  </defs>
+  <rect
+     style="fill:none;stroke:#a8a8a8;stroke-width:2;stroke-linecap:round;stroke-dasharray:none;paint-order:markers stroke fill;stroke-opacity:1"
+     id="rect1"
+     width="14"
+     height="14"
+     x="1"
+     y="1"
+     rx="1"
+     ry="1" />
+</svg>

--- a/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.ui/elcl16/expandall.svg
+++ b/iconpacks/eclipse-dual-tone/dual-tone-icons/org.eclipse.ui/elcl16/expandall.svg
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   version="1.1"
+   xml:space="preserve"
+   style="fill-rule:evenodd;clip-rule:evenodd;stroke-linecap:round;"
+   id="svg1"
+   sodipodi:docname="expandall.svg"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:serif="http://www.serif.com/"><defs
+   id="defs1" /><sodipodi:namedview
+   id="namedview1"
+   pagecolor="#ffffff"
+   bordercolor="#000000"
+   borderopacity="0.25"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   inkscape:zoom="48.3125"
+   inkscape:cx="7.9896507"
+   inkscape:cy="8"
+   inkscape:window-width="1920"
+   inkscape:window-height="991"
+   inkscape:window-x="-9"
+   inkscape:window-y="-9"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="svg1" />
+    <path
+   id="rect5"
+   d="M12.5,8C12.5,8.552 12.052,9 11.5,9L4.5,9C3.948,9 3.5,8.552 3.5,8C3.5,7.448 3.948,7 4.5,7L11.5,7C12.052,7 12.5,7.448 12.5,8Z"
+   style="fill:rgb(168,168,168);" />
+    <g
+   id="rect51"
+   serif:id="rect5"
+   transform="matrix(0,1,-1,0,16,-0)">
+        <path
+   d="M12.5,8C12.5,8.552 12.052,9 11.5,9L4.5,9C3.948,9 3.5,8.552 3.5,8C3.5,7.448 3.948,7 4.5,7L11.5,7C12.052,7 12.5,7.448 12.5,8Z"
+   style="fill:rgb(168,168,168);"
+   id="path1" />
+    </g>
+    <path
+   id="rect1"
+   d="M15,2L15,14C15,14.552 14.552,15 14,15L2,15C1.448,15 1,14.552 1,14L1,2C1,1.448 1.448,1 2,1L14,1C14.552,1 15,1.448 15,2Z"
+   style="fill:none;stroke:rgb(168,168,168);stroke-width:2px;" />
+</svg>


### PR DESCRIPTION
Fixes https://github.com/eclipse-platform/ui-best-practices/issues/157
Fixes https://github.com/eclipse-platform/ui-best-practices/issues/168

The collapseall.svg Icon was already designed. 
After discussing the look of the two Icons @Michael5601 and I decided to remove the double frames and leave the Icons more simple and cohesive. 