### PR TITLE
Adds mapping for the folder icon

### DIFF
--- a/iconpacks/eclipse-dual-tone/icon-mapping.json
+++ b/iconpacks/eclipse-dual-tone/icon-mapping.json
@@ -219,6 +219,7 @@
   ]
   ,
   "folder.svg": [
+	"org.eclipse.ui/icons/full/obj16/fldr_obj.svg",
     "org.eclipse.debug.ui/icons/full/obj16/fldr_obj.svg",
     "org.eclipse.e4.ui.workbench.swt/icons/full/obj16/fldr_obj.svg",
     "org.eclipse.mylyn.tasks.ui/icons/etool16/category.svg",


### PR DESCRIPTION
This will use the new folder icon in all places in which the folder from platform is used, e.g. Git staging, project explorer, package explorer, view dialog, etc.