### PR TITLE
Add Icon Replacement Algorithm

### DIFF
--- a/iconpacks/IconReplacementAlgorithm/IconReplacer.java
+++ b/iconpacks/IconReplacementAlgorithm/IconReplacer.java
@@ -1,0 +1,65 @@
+import java.io.*;
+import java.nio.file.*;
+import java.util.*;
+import java.util.regex.*;
+
+public class IconReplacer {
+    public static void main(String[] args) throws Exception {
+        if (args.length != 2) {
+            System.out.println("Usage: IconReplacer <eclipse-dual-tone-directory> <git-repositories-root-directory>");
+            return;
+        }
+        Path dualToneIconPackDirectory = Paths.get(args[0]);
+        Path repositoriesDirectory = Paths.get(args[1]);
+        Path mappingFile = dualToneIconPackDirectory.resolve("icon-mapping.json");
+        Path iconsDirectory = dualToneIconPackDirectory.resolve("dual-tone-icons");
+
+        Map<String, List<String>> iconMapping = parseIconMapping(mappingFile);
+
+        for (Map.Entry<String, List<String>> entry : iconMapping.entrySet()) {
+            String newIconName = entry.getKey();
+            Path newIconPath = iconsDirectory.resolve(newIconName);
+            if (!Files.exists(newIconPath)) {
+                System.out.println("New icon not found: " + newIconPath);
+                continue;
+            }
+            for (String oldIconRelativePath : entry.getValue()) {
+                // Search for old icon in all repos
+                try {
+                    Files.walk(repositoriesDirectory)
+                            .filter(p -> p.toString().endsWith(oldIconRelativePath.replace("/", File.separator)))
+                            .forEach(oldIconPath -> {
+                                try {
+                                    Files.copy(newIconPath, oldIconPath, StandardCopyOption.REPLACE_EXISTING);
+                                    System.out.println("Replaced: " + oldIconPath);
+                                } catch (IOException e) {
+                                    System.out.println("Failed to replace: " + oldIconPath);
+                                }
+                            });
+                } catch (IOException e) {
+                    System.out.println("Error searching for: " + oldIconRelativePath);
+                }
+            }
+        }
+    }
+
+    // JSON parser for icon-mapping.json
+    private static Map<String, List<String>> parseIconMapping(Path mappingFile) throws IOException {
+        Map<String, List<String>> map = new LinkedHashMap<>();
+        String content = new String(Files.readAllBytes(mappingFile));
+        Pattern entryPattern = Pattern.compile("\"([^\"]+)\"\\s*:\\s*\\[(.*?)\\]", Pattern.DOTALL);
+        Matcher matcher = entryPattern.matcher(content);
+        while (matcher.find()) {
+            String key = matcher.group(1);
+            String valueList = matcher.group(2);
+            List<String> values = new ArrayList<>();
+            Pattern valuePattern = Pattern.compile("\"([^\"]+)\"");
+            Matcher valueMatcher = valuePattern.matcher(valueList);
+            while (valueMatcher.find()) {
+                values.add(valueMatcher.group(1));
+            }
+            map.put(key, values);
+        }
+        return map;
+    }
+}

--- a/iconpacks/IconReplacementAlgorithm/USAGE.md
+++ b/iconpacks/IconReplacementAlgorithm/USAGE.md
@@ -1,0 +1,31 @@
+# IconReplacer Usage Manual
+
+## Overview
+
+`IconReplacer` is a Java tool to replace icons in the Eclipse workspace repositories with a new icon pack, based on a mapping file. This tool does NOT replace icons of an eclipse installation but only icons that are loaded into the workspace. After the replacement an eclipse instance with the new icons can be started in the eclipse run configuration. The tool is fully written in Java and does not use any third party dependencies.
+
+## Prerequisites
+- The `icon-mapping.json` and `dual-tone-icons` folder must be present in your dual-tone icon pack directory
+- All target repositories must be accessible in a single root directory
+
+## Compilation
+In a terminal navigate to the folder containing `IconReplacer.java` and run:
+
+```
+javac IconReplacer.java
+```
+
+## Usage
+Run the tool with two arguments:
+
+```
+java IconReplacer <eclipse-dual-tone-directory> <git-repositories-root-directory>
+```
+
+- `<eclipse-dual-tone-directory>`: Path to the directory containing `icon-mapping.json` and `dual-tone-icons`.
+- `<git-repositories-root-directory>`: Path to the root directory containing all Eclipse workspace repositories.
+
+### Example
+```
+java IconReplacer D:/dev/ui-best-practices/iconpacks/eclipse-dual-tone D:/dev/oomph/eclipse-installation/git
+```


### PR DESCRIPTION
This PR adds a simple java algorithm to replace icons in the workspace of a eclipse instance for testing purposes. Afterwards an eclipse with replaced icons can be started via the run menu. I added a usage manual file describing the usage of the algorithm.

Please note that this only changes icons of repositories that are loaded into the workspace. If e.g. the eclipse JDT repository is not present, no JDT icons will be replaced.

@vogella as we discussed this algorithm serves a whole different use case than the algorithm you wrote. I thus am in favor to add both algorithms, so folks can choose if they either want to replace all icons of their eclipse installation (your algorithm) or all icons in the workspace of their eclipse installation to start a new eclipse with replaced icons (this proposed algorithm). 

The following screenshot shows the replaced icons with the disablement algorithm `desaturated` which can be activated by adding `-Dorg.eclipse.swt.image.disablement=desaturated` as an argument to the run configuration:

<img width="1918" height="1020" alt="image" src="https://github.com/user-attachments/assets/a8c45b9d-4ccc-48f4-8b8a-9514d4ead466" />
