### PR TITLE
Pde perspective

### DIFF
--- a/iconpacks/eclipse-dual-tone/dual-tone-icons/plugins.svg
+++ b/iconpacks/eclipse-dual-tone/dual-tone-icons/plugins.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   fill="none"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="plugin.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.0"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#545454"
+     inkscape:zoom="32"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <!-- Puzzle piece body with top tab and right tab -->
+  <path
+     id="plugin-body"
+     style="fill:#a8a8a8;stroke:none;paint-order:markers stroke fill"
+     d="M 1,3 L 4,3 L 4,1 L 8,1 L 8,3 L 12,3 L 12,6 L 15,6 L 15,10 L 12,10 L 12,15 L 1,15 Z" />
+</svg>

--- a/iconpacks/eclipse-dual-tone/icon-mapping.json
+++ b/iconpacks/eclipse-dual-tone/icon-mapping.json
@@ -308,6 +308,9 @@
     "org.eclipse.team.cvs.ui/icons/full/elcl16/local_history_mode.svg",
     "org.eclipse.ui/icons/full/eview16/new_persp.svg"
   ],
+  "plugins.svg": [
+    "org.eclipse.pde.ui/icons/eview16/plugins.svg"
+  ],
   "project.svg": [
     "org.eclipse.debug.ui/icons/full/obj16/prj_obj.svg",
     "org.eclipse.jdt.debug.ui/icons/full/obj16/prj_obj.svg"


### PR DESCRIPTION
Adds plugins.svg and mapping
Currently not the focus of the UI team but of the main perspective for
PDE developer hence adding a svg. It can be replaced later a later point
if the designer start working on the PDE icons