### PR TITLE
Add view_menu.svg mapping for e4 renderer bundle

### DIFF
--- a/iconpacks/eclipse-dual-tone/icon-mapping.json
+++ b/iconpacks/eclipse-dual-tone/icon-mapping.json
@@ -636,7 +636,8 @@
   "options.svg" : [
     "org.eclipse.ui/icons/full/elcl16/view_menu.svg",
     "org.eclipse.ui/icons/full/elcl16/thin_view_menu.svg",
-    "org.eclipse.ui/icons/full/elcl16/button_menu.svg"
+    "org.eclipse.ui/icons/full/elcl16/button_menu.svg",
+    "org.eclipse.e4.ui.workbench.renderers.swt/icons/full/elcl16/view_menu.svg"
   ],
   "show-in-history-view.svg" : [
     "org.eclipse.team.ui/icons/full/eview16/history_view.svg"


### PR DESCRIPTION
## Summary
- The `StackRenderer` in `org.eclipse.e4.ui.workbench.renderers.swt` hardcodes the view menu icon URI to `platform:/plugin/org.eclipse.e4.ui.workbench.renderers.swt/icons/full/elcl16/view_menu.svg`
- The existing mapping only covered `org.eclipse.ui`, so the replacement script never touched the icon that's actually displayed at runtime
- Added the missing `org.eclipse.e4.ui.workbench.renderers.swt` path to the `options.svg` mapping

## Test plan
- [ ] Run `replace_icons.sh` against an Eclipse installation
- [ ] Verify the view menu chevron on view toolbars now shows the new dual-tone icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)